### PR TITLE
Log output rearrangement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ vendor
 .vscode
 logs
 *.log
+*.log.*
 .idea
 postgres/sqlboiler.toml

--- a/exchanges/hubs.go
+++ b/exchanges/hubs.go
@@ -72,7 +72,7 @@ func (hub *TickHub) CollectShort(ctx context.Context) {
 			break
 		}
 		wg.Add(1)
-		go func(ctx context.Context, wg *sync.WaitGroup, collector ticks.Collector) {
+		func(ctx context.Context, wg *sync.WaitGroup, collector ticks.Collector) {
 			err := collector.GetShort(ctx)
 			if err != nil {
 				log.Error(err)
@@ -92,7 +92,7 @@ func (hub *TickHub) CollectLong(ctx context.Context) {
 			break
 		}
 		wg.Add(1)
-		go func(ctx context.Context, wg *sync.WaitGroup, collector ticks.Collector) {
+		func(ctx context.Context, wg *sync.WaitGroup, collector ticks.Collector) {
 			err := collector.GetLong(ctx)
 			if err != nil {
 				log.Error(err)
@@ -112,7 +112,7 @@ func (hub *TickHub) CollectHistoric(ctx context.Context) {
 			break
 		}
 		wg.Add(1)
-		go func(ctx context.Context, wg *sync.WaitGroup, collector ticks.Collector) {
+		func(ctx context.Context, wg *sync.WaitGroup, collector ticks.Collector) {
 			err := collector.GetHistoric(ctx)
 			if err != nil {
 				log.Error(err)
@@ -125,7 +125,29 @@ func (hub *TickHub) CollectHistoric(ctx context.Context) {
 }
 
 func (hub *TickHub) CollectAll(ctx context.Context) {
-	hub.CollectShort(ctx)
+	for _, collector := range hub.collectors {
+		if ctx.Err() != nil {
+			log.Error(ctx.Err())
+			break
+		}
+
+		err := collector.GetShort(ctx)
+		if err != nil {
+			log.Error(err)
+		}
+
+		err = collector.GetLong(ctx)
+		if err != nil {
+			log.Error(err)
+		}
+
+		err = collector.GetHistoric(ctx)
+		if err != nil {
+			log.Error(err)
+		}
+	}
+
+	/*hub.CollectShort(ctx)
 	if ctx.Err() != nil {
 		return
 	}
@@ -133,18 +155,18 @@ func (hub *TickHub) CollectAll(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
 	}
-	hub.CollectHistoric(ctx)
+	hub.CollectHistoric(ctx)*/
 }
 
 func (hub *TickHub) Run(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	shortTicker := time.NewTicker(5 * time.Minute)
+	/*shortTicker := time.NewTicker(5 * time.Minute)
 	longTicker := time.NewTicker(time.Hour)
 	dayTicker := time.NewTicker(24 * time.Hour)
 	defer shortTicker.Stop()
 	defer longTicker.Stop()
-	defer dayTicker.Stop()
+	defer dayTicker.Stop()*/
 
 	if ctx.Err() != nil {
 		log.Error(ctx.Err())
@@ -152,7 +174,7 @@ func (hub *TickHub) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 	hub.CollectAll(ctx)
 
-	for {
+	/*for {
 		select {
 		case <-shortTicker.C:
 			hub.CollectShort(ctx)
@@ -163,5 +185,5 @@ func (hub *TickHub) Run(ctx context.Context, wg *sync.WaitGroup) {
 		case <-ctx.Done():
 			return
 		}
-	}
+	}*/
 }

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"sync"
 	"time"
-	
+
 	"github.com/raedahgroup/dcrextdata/exchanges"
 	"github.com/raedahgroup/dcrextdata/postgres"
 	"github.com/raedahgroup/dcrextdata/pow"

--- a/postgres/exchange_ticks.go
+++ b/postgres/exchange_ticks.go
@@ -107,16 +107,20 @@ func (pg *PgDb) StoreExchangeTicks(ctx context.Context, name string, interval in
 		added++
 	}
 
-	//name = 10, pair: 7, interval: 7
-	const dateTemplate = "2006-01-02 15:04"
 	if added == 0 {
 		log.Infof("No new ticks on %s(%dm) for", name, pair, interval)
 	} else if added == 1 {
-		// bleutrade, received 87 ticks (240m each)
-		log.Infof("%10s %7s, received      1  tick %14s %s", name, pair, fmt.Sprintf("(%dm)", interval), firstTime.Format(dateTemplate))
+		log.Infof("%10s %7s, received %6dm ticks, storing      1 entries %s", name, pair,
+			interval, firstTime.Format(dateTemplate))
+
+		/*log.Infof("%10s %7s, received      1  tick %14s %s", name, pair,
+			fmt.Sprintf("(%dm)", interval), firstTime.Format(dateTemplate))*/
 	} else {
-		log.Infof("%10s %7s, received %6v ticks %14s %s to %s",
-			name, pair, added, fmt.Sprintf("(%dm each)", interval), firstTime.Format(dateTemplate), lastTime.Format(dateTemplate))
+		log.Infof("%10s %7s, received %6dm ticks, storing %6v entries %s to %s", name, pair,
+			interval, added, firstTime.Format(dateTemplate), lastTime.Format(dateTemplate))
+
+		/*log.Infof("%10s %7s, received %6v ticks %14s %s to %s",
+			name, pair, added, fmt.Sprintf("(%dm each)", interval), firstTime.Format(dateTemplate), lastTime.Format(dateTemplate))*/
 	}
 	return lastTime, nil
 }

--- a/postgres/exchange_ticks.go
+++ b/postgres/exchange_ticks.go
@@ -110,10 +110,11 @@ func (pg *PgDb) StoreExchangeTicks(ctx context.Context, name string, interval in
 	if added == 0 {
 		log.Infof("No new ticks for %s(%dm)", name, interval)
 	} else if added == 1 {
-		log.Infof("Stored an exchange tick for %s(%dm) at %v", name, interval, firstTime)
+		// bleutrade, received 87 ticks (240m each)
+		log.Infof("%v - %s, received 1 tick (%dm)", firstTime, name, interval)
 	} else {
-		log.Infof("Stored %d exchange ticks for %s(%dm) from %v to %v", added, name, interval,
-			firstTime, lastTime)
+		log.Infof("%v to %v - %s, received %d ticks (%dm each)", firstTime, lastTime,
+			name, added, interval)
 	}
 	return lastTime, nil
 }

--- a/postgres/exchange_ticks.go
+++ b/postgres/exchange_ticks.go
@@ -107,14 +107,16 @@ func (pg *PgDb) StoreExchangeTicks(ctx context.Context, name string, interval in
 		added++
 	}
 
+	//name = 10, pair: 7, interval: 7
+	const dateTemplate = "2006-01-02 15:04"
 	if added == 0 {
-		log.Infof("No new ticks on %s(%dm) for", name, interval, pair)
+		log.Infof("No new ticks on %s(%dm) for", name, pair, interval)
 	} else if added == 1 {
 		// bleutrade, received 87 ticks (240m each)
-		log.Infof("%v - %s, received 1 tick (%dm) for %s", firstTime, name, interval, pair)
+		log.Infof("%10s %7s, received      1  tick %14s %s", name, pair, fmt.Sprintf("(%dm)", interval), firstTime.Format(dateTemplate))
 	} else {
-		log.Infof("%v to %v - %s, received %d ticks (%dm each) for %s", firstTime, lastTime,
-			name, added, interval, pair)
+		log.Infof("%10s %7s, received %6v ticks %14s %s to %s",
+			name, pair, added, fmt.Sprintf("(%dm each)", interval), firstTime.Format(dateTemplate), lastTime.Format(dateTemplate))
 	}
 	return lastTime, nil
 }

--- a/postgres/exchange_ticks.go
+++ b/postgres/exchange_ticks.go
@@ -110,13 +110,13 @@ func (pg *PgDb) StoreExchangeTicks(ctx context.Context, name string, interval in
 	if added == 0 {
 		log.Infof("No new ticks on %s(%dm) for", name, pair, interval)
 	} else if added == 1 {
-		log.Infof("%10s %7s, received %6dm ticks, storing      1 entries %s", name, pair,
+		log.Infof("%-9s %7s, received %6dm ticks, storing      1 entries %s", name, pair,
 			interval, firstTime.Format(dateTemplate))
 
 		/*log.Infof("%10s %7s, received      1  tick %14s %s", name, pair,
 			fmt.Sprintf("(%dm)", interval), firstTime.Format(dateTemplate))*/
 	} else {
-		log.Infof("%10s %7s, received %6dm ticks, storing %6v entries %s to %s", name, pair,
+		log.Infof("%-9s %7s, received %6dm ticks, storing %6v entries %s to %s", name, pair,
 			interval, added, firstTime.Format(dateTemplate), lastTime.Format(dateTemplate))
 
 		/*log.Infof("%10s %7s, received %6v ticks %14s %s to %s",

--- a/postgres/exchange_ticks.go
+++ b/postgres/exchange_ticks.go
@@ -108,13 +108,13 @@ func (pg *PgDb) StoreExchangeTicks(ctx context.Context, name string, interval in
 	}
 
 	if added == 0 {
-		log.Infof("No new ticks for %s(%dm)", name, interval)
+		log.Infof("No new ticks on %s(%dm) for", name, interval, pair)
 	} else if added == 1 {
 		// bleutrade, received 87 ticks (240m each)
-		log.Infof("%v - %s, received 1 tick (%dm)", firstTime, name, interval)
+		log.Infof("%v - %s, received 1 tick (%dm) for %s", firstTime, name, interval, pair)
 	} else {
-		log.Infof("%v to %v - %s, received %d ticks (%dm each)", firstTime, lastTime,
-			name, added, interval)
+		log.Infof("%v to %v - %s, received %d ticks (%dm each) for %s", firstTime, lastTime,
+			name, added, interval, pair)
 	}
 	return lastTime, nil
 }

--- a/postgres/helpers.go
+++ b/postgres/helpers.go
@@ -12,6 +12,8 @@ import (
 	"github.com/volatiletech/sqlboiler/boil"
 )
 
+const dateTemplate = "2006-01-02 15:04"
+
 type insertable interface {
 	Insert(context.Context, boil.ContextExecutor, boil.Columns) error
 }

--- a/postgres/helpers.go
+++ b/postgres/helpers.go
@@ -23,7 +23,7 @@ type upsertable interface {
 }
 
 func UnixTimeToString(t int64) string {
-	return time.Unix(t, 0).UTC().String()
+	return time.Unix(t, 0).UTC().Format(dateTemplate)
 }
 
 func int64ToTime(t int64) time.Time {

--- a/postgres/pow.go
+++ b/postgres/pow.go
@@ -19,6 +19,10 @@ func (pg *PgDb) LastPowEntryTime(source string) (time int64) {
 
 //
 func (pg *PgDb) AddPowData(ctx context.Context, data []pow.PowData) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	added := 0
 	for _, d := range data {
 		powModel, err := responseToPowModel(d)
@@ -35,10 +39,10 @@ func (pg *PgDb) AddPowData(ctx context.Context, data []pow.PowData) error {
 		added++
 	}
 	if len(data) == 1 {
-		log.Infof("%s - Added %d pow entry from %s", UnixTimeToString(data[0].Time), added, data[0].Source)
+		log.Infof("%s - Added %d PoW entry from %s", UnixTimeToString(data[0].Time), added, data[0].Source)
 	} else if len(data) > 1 {
 		last := data[len(data)-1]
-		log.Infof("%s to %s - Added %d pow entries from %s",
+		log.Infof("%s to %s - Added %d PoW entries from %s",
 			UnixTimeToString(data[0].Time), UnixTimeToString(last.Time), added, last.Source)
 	}
 

--- a/postgres/pow.go
+++ b/postgres/pow.go
@@ -39,11 +39,11 @@ func (pg *PgDb) AddPowData(ctx context.Context, data []pow.PowData) error {
 		added++
 	}
 	if len(data) == 1 {
-		log.Infof("%s - Added %d PoW entry from %s", UnixTimeToString(data[0].Time), added, data[0].Source)
+		log.Infof("Added %4d PoW   entry from %10s %s", added, data[0].Source, UnixTimeToString(data[0].Time))
 	} else if len(data) > 1 {
 		last := data[len(data)-1]
-		log.Infof("%s to %s - Added %d PoW entries from %s",
-			UnixTimeToString(data[0].Time), UnixTimeToString(last.Time), added, last.Source)
+		log.Infof("Added %4d PoW entries from %10s %s to %s",
+			added, last.Source, UnixTimeToString(data[0].Time), UnixTimeToString(last.Time),)
 	}
 
 	return nil

--- a/postgres/pow.go
+++ b/postgres/pow.go
@@ -35,12 +35,11 @@ func (pg *PgDb) AddPowData(ctx context.Context, data []pow.PowData) error {
 		added++
 	}
 	if len(data) == 1 {
-		log.Infof("Added %d pow entry from %s (%s)", added, data[0].Source,
-			UnixTimeToString(data[0].Time))
+		log.Infof("%s - Added %d pow entry from %s", UnixTimeToString(data[0].Time), added, data[0].Source)
 	} else {
 		last := data[len(data)-1]
-		log.Infof("Added %d pow entries from %s (%s to %s)", added, last.Source,
-			UnixTimeToString(data[0].Time), UnixTimeToString(last.Time))
+		log.Infof("%s to %s - Added %d pow entries from %s",
+			UnixTimeToString(data[0].Time), UnixTimeToString(last.Time), added, last.Source)
 	}
 
 	return nil

--- a/postgres/pow.go
+++ b/postgres/pow.go
@@ -36,7 +36,7 @@ func (pg *PgDb) AddPowData(ctx context.Context, data []pow.PowData) error {
 	}
 	if len(data) == 1 {
 		log.Infof("%s - Added %d pow entry from %s", UnixTimeToString(data[0].Time), added, data[0].Source)
-	} else {
+	} else if len(data) > 1 {
 		last := data[len(data)-1]
 		log.Infof("%s to %s - Added %d pow entries from %s",
 			UnixTimeToString(data[0].Time), UnixTimeToString(last.Time), added, last.Source)

--- a/postgres/vsp.go
+++ b/postgres/vsp.go
@@ -119,7 +119,7 @@ func (pg *PgDb) storeVspResponse(ctx context.Context, name string, resp *vsp.Res
 		return txr.Rollback()
 	}
 
-	log.Infof("%v - Stored data for vsp %s", tickTime.UTC(), name)
+	log.Infof("Stored data for VSP %10s %v", name, tickTime.UTC().Format(dateTemplate))
 	return nil
 }
 

--- a/postgres/vsp.go
+++ b/postgres/vsp.go
@@ -119,7 +119,7 @@ func (pg *PgDb) storeVspResponse(ctx context.Context, name string, resp *vsp.Res
 		return txr.Rollback()
 	}
 
-	log.Tracef("Stored data for vsp %s at %v", name, tickTime.UTC())
+	log.Tracef("%v - Stored data for vsp %s", tickTime.UTC(), name)
 	return nil
 }
 

--- a/postgres/vsp.go
+++ b/postgres/vsp.go
@@ -119,7 +119,7 @@ func (pg *PgDb) storeVspResponse(ctx context.Context, name string, resp *vsp.Res
 		return txr.Rollback()
 	}
 
-	log.Tracef("%v - Stored data for vsp %s", tickTime.UTC(), name)
+	log.Infof("%v - Stored data for vsp %s", tickTime.UTC(), name)
 	return nil
 }
 

--- a/pow/collectors.go
+++ b/pow/collectors.go
@@ -98,7 +98,7 @@ func (pc *Collector) Collect(ctx context.Context, wg *sync.WaitGroup) {
 		case <-ticker.C:
 			runPowCollectors()
 		case <-ctx.Done():
-			log.Infof("Stopping collector")
+			log.Infof("Stopping collectors")
 			return
 		}
 

--- a/pow/collectors.go
+++ b/pow/collectors.go
@@ -6,7 +6,6 @@ package pow
 
 import (
 	"context"
-	"github.com/raedahgroup/dcrextdata/helpers"
 	"net/http"
 	"sync"
 	"time"
@@ -68,15 +67,15 @@ func (pc *Collector) Collect(ctx context.Context, wg *sync.WaitGroup) {
 	}
 
 	runPowCollectors := func() {
-		log.Trace("Triggering PoW collectors")
+		log.Info("Triggering PoW collectors")
 		for _, in := range pc.pows {
 			func(powInfo Pow) {
-				lastEntryTime := pc.store.LastPowEntryTime(powInfo.Name())
+				/*lastEntryTime := pc.store.LastPowEntryTime(powInfo.Name())
 				lastStr := helpers.UnixTimeToString(in.LastUpdateTime())
 				if lastEntryTime == 0 {
 					lastStr = "never"
 				}
-				log.Infof("Starting PoW collector for %s, last collect time: %s", powInfo.Name(), lastStr)
+				log.Infof("Starting PoW collector for %s, last collect time: %s", powInfo.Name(), lastStr)*/
 
 				data, err := powInfo.Collect(ctx)
 				if err != nil {

--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -93,7 +93,7 @@ func (vsp *Collector) collectAndStore(ctx context.Context) error {
 		err = vsp.fetch(ctx, resp)
 	}
 
-	log.Infof("Collected data for %d vsps", len(*resp))
+	// log.Infof("Collected data for %d vsps", len(*resp))
 
 	errs := vsp.dataStore.StoreVSPs(ctx, *resp)
 	for _, err = range errs {

--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -56,7 +56,7 @@ func (vsp *Collector) Run(ctx context.Context, wg *sync.WaitGroup) {
 		return
 	}
 
-	log.Info("Starting collection cycle")
+	log.Info("Starting VSP collection cycle")
 	if err := vsp.collectAndStore(ctx); err != nil {
 		log.Errorf("Could not start collection: %v", err)
 		return

--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -62,7 +62,7 @@ func (vsp *Collector) Run(ctx context.Context, wg *sync.WaitGroup) {
 		return
 	}
 
-	ticker := time.NewTicker(vsp.period * time.Second)
+	/*ticker := time.NewTicker(vsp.period * time.Second)
 	defer ticker.Stop()
 
 	for {
@@ -75,7 +75,7 @@ func (vsp *Collector) Run(ctx context.Context, wg *sync.WaitGroup) {
 			log.Infof("Shutting down collector")
 			return
 		}
-	}
+	}*/
 }
 
 func (vsp *Collector) collectAndStore(ctx context.Context) error {

--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -57,6 +57,7 @@ func (vsp *Collector) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 
 	log.Info("Starting VSP collection cycle")
+	log.Info("Fetching VSP from source")
 	if err := vsp.collectAndStore(ctx); err != nil {
 		log.Errorf("Could not start collection: %v", err)
 		return


### PR DESCRIPTION
This PR rearrange the log output by running all the data collector on a single thread to avoid the random output log. 

![image](https://user-images.githubusercontent.com/11990092/59557555-a83e3a80-8fd4-11e9-9229-87e2bac79e48.png)
