### PR TITLE
implemented terminal prompt for reset command

### DIFF
--- a/app/help/utils.go
+++ b/app/help/utils.go
@@ -12,7 +12,6 @@ import (
 	"github.com/raedahgroup/dcrextdata/app"
 )
 
-
 //TabWriter creates a tabwriter object that writes tab-aligned text.
 func TabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 0, 0, 1, ' ', tabwriter.TabIndent)

--- a/app/help/utils.go
+++ b/app/help/utils.go
@@ -3,6 +3,7 @@ package help
 import (
 	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"strings"
 	"text/tabwriter"
@@ -11,10 +12,14 @@ import (
 	"github.com/raedahgroup/dcrextdata/app"
 )
 
+
 //TabWriter creates a tabwriter object that writes tab-aligned text.
 func TabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 0, 0, 1, ' ', tabwriter.TabIndent)
 }
+
+// StdoutWriter writes tab-aligned text to os.Stdout
+var StdoutWriter = TabWriter(os.Stdout)
 
 // printOptionGroups checks if the root parser option group has nested option groups and prints all
 func printOptionGroups(output io.Writer, groups []*flags.Group) {

--- a/app/helpers/terminalprompt.go
+++ b/app/helpers/terminalprompt.go
@@ -1,0 +1,109 @@
+package helpers
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/raedahgroup/dcrextdata/app/help"
+)
+
+// ValidatorFunction  validates the input string according to its custom logic.
+type ValidatorFunction func(string) error
+
+// getTextInput - Prompt for text input.
+func getTextInput(prompt string) (string, error) {
+	// printing the prompt with tabWriter to ensure adequate formatting of tabulated list of options
+	tabWriter := help.StdoutWriter
+	fmt.Fprint(tabWriter, prompt)
+	tabWriter.Flush()
+
+	reader := bufio.NewReader(os.Stdin)
+	text, err := reader.ReadString('\n')
+
+	if err != nil {
+		return "", err
+	}
+
+	text = strings.TrimSuffix(text, "\n")
+	text = strings.TrimSuffix(text, "\r")
+
+	return text, nil
+}
+
+func skipEOFError(value string, err error) (string, error) {
+	switch err {
+	case io.EOF:
+		return "", nil
+	case nil:
+		return value, nil
+	default:
+		return "", err
+	}
+}
+
+// RequestInput requests input from the user.
+// If an error other than EOF occurs while requesting input, the error is returned.
+// It calls `validate` on the received input. If `validate` returns an error, the user is prompted
+// again for a correct input.
+func RequestInput(message string, validate ValidatorFunction) (string, error) {
+	for {
+		value, err := skipEOFError(getTextInput(fmt.Sprintf("%s: ", message)))
+		if err != nil {
+			return "", err
+		}
+
+		value = strings.TrimSpace(value)
+		if err = validate(value); err != nil {
+			fmt.Println(strings.TrimSpace(err.Error()))
+			continue
+		}
+		return value, nil
+	}
+}
+
+func RequestYesNoConfirmation(message, defaultOption string) (bool, error) {
+	isYesOption := func(option string) bool {
+		return strings.EqualFold(option, "y") || strings.EqualFold(option, "yes")
+	}
+	isNoOption := func(option string) bool {
+		return strings.EqualFold(option, "n") || strings.EqualFold(option, "no")
+	}
+
+	validateUserResponse := func(userResponse string) error {
+		if defaultOption != "" && userResponse == "" {
+			return nil
+		}
+		if isYesOption(userResponse) || isNoOption(userResponse) {
+			return nil
+		}
+		fmt.Println()
+		return fmt.Errorf("Invalid option, try again")
+	}
+
+	var options string
+	if isYesOption(defaultOption) {
+		options = "Y/n"
+	} else if isNoOption(defaultOption) {
+		options = "y/N"
+	} else {
+		options = "y/n"
+		defaultOption = ""
+	}
+
+	// append options to message for display
+	message = fmt.Sprintf("%s (%s)", message, options)
+	userResponse, err := RequestInput(message, validateUserResponse)
+	if err != nil {
+		return false, err
+	}
+
+	userResponse = strings.TrimSpace(userResponse)
+	if userResponse == "" {
+		userResponse = defaultOption
+	}
+
+	return isYesOption(userResponse), nil
+}

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func _main(ctx context.Context) error {
 		}
 	}(db)
 
-	if cfg.Reset {		
+	if cfg.Reset {
 		fmt.Println()
 		resetTables, err := helpers.RequestYesNoConfirmation("You are about to reset/drop all database table(s). Proceed?", "N")
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/raedahgroup/dcrextdata/app"
 	"github.com/raedahgroup/dcrextdata/app/config"
 	"github.com/raedahgroup/dcrextdata/app/help"
+	"github.com/raedahgroup/dcrextdata/app/helpers"
 	"github.com/raedahgroup/dcrextdata/exchanges"
 	"github.com/raedahgroup/dcrextdata/mempool"
 	"github.com/raedahgroup/dcrextdata/postgres"
@@ -116,15 +117,27 @@ func _main(ctx context.Context) error {
 		}
 	}(db)
 
-	if cfg.Reset {
-		log.Info("Dropping tables")
-		err = db.DropAllTables()
+	if cfg.Reset {		
+		fmt.Println()
+		resetTables, err := helpers.RequestYesNoConfirmation("You are about to reset/drop all database table(s). Proceed?", "N")
 		if err != nil {
-			db.Close()
-			log.Error("Could not drop tables: ", err)
-			return err
+			return fmt.Errorf("error reading your response: %s", err.Error())
 		}
-		log.Info("Tables dropped")
+
+		if resetTables {
+			log.Info("Dropping tables")
+			err = db.DropAllTables()
+			if err != nil {
+				db.Close()
+				log.Error("Could not drop tables: ", err)
+				return err
+			}
+
+			log.Info("Tables dropped")
+			return nil
+		}
+
+		return nil
 	}
 
 	if cfg.HttpMode {


### PR DESCRIPTION
fixes #51 
when  a user uses the reset command user is prompted to verify action. Then after tables are dropped, code breaks out rather than fetch new set of data.

![image](https://user-images.githubusercontent.com/27733432/60847387-6cb11d80-a1da-11e9-8bc3-1fea15d85b6c.png)
