### PR TITLE
Resolved error on first run: no row found

### DIFF
--- a/postgres/mempool.go
+++ b/postgres/mempool.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -50,6 +51,9 @@ func (pg *PgDb) LastMempoolBlockHeight() (height int64, err error) {
 func (pg *PgDb) LastMempoolTime() (entryTime time.Time, err error) {
 	rows := pg.db.QueryRow(lastMempoolEntryTime)
 	err = rows.Scan(&entryTime)
+	if err == sql.ErrNoRows {
+		err = nil
+	}
 	return
 }
 

--- a/postgres/pow.go
+++ b/postgres/pow.go
@@ -26,7 +26,9 @@ func (pg *PgDb) LastPowEntryTime(source string) (time int64) {
 
 	err := rows.Scan(&time)
 	if err != nil {
-		log.Errorf("Error in getting last PoW entry time: %s", err.Error())
+		if err != sql.ErrNoRows {
+			log.Errorf("Error in getting last PoW entry time: %s", err.Error())
+		}
 	}
 	return
 }


### PR DESCRIPTION
Resolves #59 
No showing 'no rows in result set' error for fetching last record time.