### PR TITLE
Vsp module/page

### DIFF
--- a/postgres/vsp.go
+++ b/postgres/vsp.go
@@ -214,6 +214,7 @@ func (pg *PgDb) LastVspTickEntryTime() (time time.Time) {
 }
 
 func (pg *PgDb) FetchChartData(ctx context.Context, attribute string, vspName string) (records []vsp.ChartData, err error) {
+	attribute = strings.ToLower(attribute)
 	vspInfo, err := models.VSPS(models.VSPWhere.Name.EQ(null.StringFrom(vspName))).One(ctx, pg.db)
 	if err != nil {
 		return nil, err
@@ -229,6 +230,13 @@ func (pg *PgDb) FetchChartData(ctx context.Context, attribute string, vspName st
 		err = rows.Scan(&rec.Date, &rec.Record)
 		if err != nil {
 			return nil, err
+		}
+		if attribute == models.VSPTickColumns.ProportionLive || attribute == models.VSPTickColumns.ProportionMissed {
+			value, err := strconv.ParseFloat(rec.Record, 64)
+			if err != nil {
+				return nil, err
+			}
+			rec.Record = RoundValue(value)
 		}
 		records = append(records, rec)
 	}

--- a/postgres/vsp.go
+++ b/postgres/vsp.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -123,13 +124,17 @@ func (pg *PgDb) FetchVSPs(ctx context.Context) ([]vsp.VSPDto, error) {
 
 	var result []vsp.VSPDto
 	for _, item := range vspData {
-
+		parsedURL, err := url.Parse(item.URL.String)
+		if err != nil {
+			return nil, err
+		}
 		result = append(result, vsp.VSPDto{
 			Name:                 item.Name.String,
 			APIEnabled:           item.APIEnabled.Bool,
 			APIVersionsSupported: item.APIVersionsSupported,
 			Network:              item.Network.String,
 			URL:                  item.URL.String,
+			Host:                 parsedURL.Host,
 			Launched:             item.Launched.Time,
 		})
 	}

--- a/vsp/types.go
+++ b/vsp/types.go
@@ -56,7 +56,7 @@ type ResposeData struct {
 }
 
 type DataStore interface {
-	StoreVSPs(context.Context, Response) []error
+	StoreVSPs(context.Context, Response) (int, []error)
 	LastVspTickEntryTime() (time time.Time)
 }
 

--- a/vsp/types.go
+++ b/vsp/types.go
@@ -19,6 +19,7 @@ type VSPDto struct {
 	APIVersionsSupported []int64   `json:"live"`
 	Network              string    `json:"voted"`
 	URL                  string    `json:"missed"`
+	Host                 string    `json:"host"`
 	Launched             time.Time `json:"pool_fees"`
 }
 

--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -65,7 +65,6 @@ func (vsp *Collector) Run(ctx context.Context) {
 
 	if secondsPassed < period {
 		timeLeft := period - secondsPassed
-		//Fetching VSPs every 5m, collected 1m7.99s ago, will fetch in 3m52.01s
 		log.Infof("Fetching VSPs every %dm, collected %s ago, will fetch in %s.", vsp.period/60, helpers.DurationToString(secondsPassed),
 			helpers.DurationToString(timeLeft))
 

--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -79,12 +79,10 @@ func (vsp *Collector) Run(ctx context.Context) {
 		}
 	}
 
-	log.Info("Fetching VSP from source")
-
 	err := vsp.collectAndStore(ctx)
 	app.ReleaseForNewModule()
 	if err != nil {
-		log.Errorf("Could not start collection: %v", err)
+		log.Errorf("Could not start collection: %s", err.Error())
 		return
 	}
 
@@ -104,7 +102,6 @@ func (vsp *Collector) Run(ctx context.Context) {
 						break
 					}
 				}
-				log.Info("Starting a VSP collection cycle")
 				err := vsp.collectAndStore(ctx)
 				app.ReleaseForNewModule()
 				if err != nil {
@@ -119,6 +116,7 @@ func (vsp *Collector) collectAndStore(ctx context.Context) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+	log.Info("Fetching VSP from source")
 
 	resp := new(Response)
 	err := vsp.fetch(ctx, resp)
@@ -129,8 +127,6 @@ func (vsp *Collector) collectAndStore(ctx context.Context) error {
 		log.Warn(err)
 		err = vsp.fetch(ctx, resp)
 	}
-
-	// log.Infof("Collected data for %d vsps", len(*resp))
 
 	numberStored, errs := vsp.dataStore.StoreVSPs(ctx, *resp)
 	for _, err = range errs {

--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -132,7 +132,7 @@ func (vsp *Collector) collectAndStore(ctx context.Context) error {
 
 	// log.Infof("Collected data for %d vsps", len(*resp))
 
-	errs := vsp.dataStore.StoreVSPs(ctx, *resp)
+	numberStored, errs := vsp.dataStore.StoreVSPs(ctx, *resp)
 	for _, err = range errs {
 		if err != nil {
 			if e, ok := err.(PoolTickTimeExistsError); ok {
@@ -143,5 +143,7 @@ func (vsp *Collector) collectAndStore(ctx context.Context) error {
 			}
 		}
 	}
+
+	log.Infof("Saved ticks for %d VSPs from %s", numberStored, requestURL)
 	return nil
 }

--- a/web/public/app/src/controllers/exchange_controller.js
+++ b/web/public/app/src/controllers/exchange_controller.js
@@ -3,7 +3,6 @@ import axios from 'axios'
 import { hide, show, legendFormatter, options } from '../utils'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
-var opt = 'table'
 
 export default class extends Controller {
   static get targets () {
@@ -16,6 +15,7 @@ export default class extends Controller {
   }
 
   initialize () {
+    this.viewOption = 'table'
     this.currentPage = parseInt(this.currentPageTarget.getAttribute('data-current-page'))
     if (this.currentPage < 1) {
       this.currentPage = 1
@@ -23,7 +23,7 @@ export default class extends Controller {
   }
 
   setTable () {
-    opt = 'table'
+    this.viewOption = 'table'
 
     this.intervalWapperTarget.classList.add('d-hide')
     this.selectedDticksTarget.value = 'close'
@@ -31,17 +31,17 @@ export default class extends Controller {
     this.sourceWrapperTarget.classList.remove('d-hide')
     this.hideOptionTarget.classList.remove('d-hide')
     this.selectedCpair = this.selectedCpairTarget.value
-    this.setActiveOptionBtn(opt, this.viewOptionTargets)
+    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     this.chartWrapperTarget.classList.add('d-hide')
     this.exchangeTableWrapperTarget.classList.remove('d-hide')
     this.numPageWrapperTarget.classList.remove('d-hide')
     this.exchangeTableTarget.innerHTML = ''
     this.nextPage = 1
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   setChart () {
-    opt = 'chart'
+    this.viewOption = 'chart'
 
     this.intervalWapperTarget.classList.remove('d-hide')
     this.tickWapperTarget.classList.remove('d-hide')
@@ -49,53 +49,53 @@ export default class extends Controller {
     this.hideOptionTarget.classList.add('d-hide')
     this.numPageWrapperTarget.classList.add('d-hide')
     this.exchangeTableWrapperTarget.classList.add('d-hide')
-    this.setActiveOptionBtn(opt, this.viewOptionTargets)
+    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     this.chartWrapperTarget.classList.remove('d-hide')
     var y = this.selectedIntervalTarget.options
     this.selectedInterval = this.selectedIntervalTarget.value = y[0].text
     this.selectedDtick = this.selectedDticksTarget.value = 'close'
     this.selectedCpair = this.selectedCpairTarget.value = 'BTC/DCR'
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   selectedIntervalChanged () {
     this.selectedInterval = this.selectedIntervalTarget.value
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   selectedDticksChanged () {
     this.selectedDtick = this.selectedDticksTarget.value
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   loadPreviousPage () {
     this.selectedCpair = this.selectedCpairTarget.value
     this.nextPage = this.previousPageButtonTarget.getAttribute('data-previous-page')
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   loadNextPage () {
     this.selectedCpair = this.selectedCpairTarget.value
     this.nextPage = this.nextPageButtonTarget.getAttribute('data-next-page')
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   selectedFilterChanged () {
     this.nextPage = 1
     this.selectedCpair = this.selectedCpairTarget.value
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   selectedCpairChanged () {
     this.nextPage = 1
     this.selectedCpair = this.selectedCpairTarget.value
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   NumberOfRowsChanged () {
     this.nextPage = 1
     this.selectedCpair = this.selectedCpairTarget.value
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   fetchExchange (display) {
@@ -218,7 +218,7 @@ export default class extends Controller {
 
   setActiveOptionBtn (opt, optTargets) {
     optTargets.forEach(li => {
-      if (li.dataset.option === opt) {
+      if (li.dataset.option === this.viewOption) {
         li.classList.add('active')
       } else {
         li.classList.remove('active')

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -24,24 +24,21 @@ export default class extends Controller {
 
   setTable () {
     this.viewOption = 'table'
-    this.chartOptionsTarget.classList.add('d-hide')
     this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
-    this.chartWrapperTarget.classList.add('d-hide')
-    this.tableWrapperTarget.classList.remove('d-hide')
-    this.btnWrapperTarget.classList.remove('d-hide')
-    this.currentPage = this.currentPage
+    hide(this.chartWrapperTarget)
+    hide(this.chartDataTypeSelectorTarget)
+    show(this.tableWrapperTarget)
+    show(this.btnWrapperTarget)
     this.fetchData(this.viewOption)
   }
 
   setChart () {
     this.viewOption = 'chart'
-    var y = this.selectedMempoolOptTarget.options
-    this.chartFilter = this.selectedMempoolOptTarget.value = y[0].value
-    this.chartOptionsTarget.classList.remove('d-hide')
-    this.btnWrapperTarget.classList.add('d-hide')
-    this.tableWrapperTarget.classList.add('d-hide')
+    show(this.chartDataTypeSelectorTarget)
+    hide(this.btnWrapperTarget)
+    hide(this.tableWrapperTarget)
     this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
-    this.chartWrapperTarget.classList.remove('d-hide')
+    show(this.chartWrapperTarget)
     this.nextPage = 1
     this.fetchData(this.viewOption)
   }

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -47,7 +47,6 @@ export default class extends Controller {
     this.chartFilter = this.selectedMempoolOptTarget.value
     this.fetchData(this.viewOption)
   }
-  
   setSizeDataType (event) {
     this.dataType = 'size'
     this.chartDataTypeTargets.forEach(el => {
@@ -164,11 +163,11 @@ export default class extends Controller {
 
     chartData.forEach(mp => {
       let date = new Date(mp.time)
-      if (minDate == null || new Date(mp.time) < minDate) {
+      if (minDate === undefined || new Date(mp.time) < minDate) {
         minDate = new Date(mp.time)
       }
 
-      if (maxDate == null || new Date(mp.time) > maxDate) {
+      if (maxDate === undefined || new Date(mp.time) > maxDate) {
         maxDate = new Date(mp.time)
       }
 

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -3,7 +3,6 @@ import axios from 'axios'
 import { legendFormatter, barChartPlotter, hide, show } from '../utils'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
-var opt = 'table'
 
 export default class extends Controller {
   static get targets () {
@@ -24,24 +23,27 @@ export default class extends Controller {
   }
 
   setTable () {
-    opt = 'table'
-    this.setActiveOptionBtn(opt, this.viewOptionTargets)
-    hide(this.chartWrapperTarget)
-    hide(this.chartDataTypeSelectorTarget)
-    show(this.tableWrapperTarget)
-    show(this.btnWrapperTarget)
-    this.fetchData(opt)
+    this.viewOption = 'table'
+    this.chartOptionsTarget.classList.add('d-hide')
+    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
+    this.chartWrapperTarget.classList.add('d-hide')
+    this.tableWrapperTarget.classList.remove('d-hide')
+    this.btnWrapperTarget.classList.remove('d-hide')
+    this.currentPage = this.currentPage
+    this.fetchData(this.viewOption)
   }
 
   setChart () {
-    opt = 'chart'
-    hide(this.btnWrapperTarget)
-    hide(this.tableWrapperTarget)
-    this.setActiveOptionBtn(opt, this.viewOptionTargets)
-    show(this.chartWrapperTarget)
-    show(this.chartDataTypeSelectorTarget)
+    this.viewOption = 'chart'
+    var y = this.selectedMempoolOptTarget.options
+    this.chartFilter = this.selectedMempoolOptTarget.value = y[0].value
+    this.chartOptionsTarget.classList.remove('d-hide')
+    this.btnWrapperTarget.classList.add('d-hide')
+    this.tableWrapperTarget.classList.add('d-hide')
+    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
+    this.chartWrapperTarget.classList.remove('d-hide')
     this.nextPage = 1
-    this.fetchData(opt)
+    this.fetchData(this.viewOption)
   }
 
   setSizeDataType (event) {
@@ -73,12 +75,12 @@ export default class extends Controller {
 
   gotoPreviousPage () {
     this.currentPage = this.currentPage - 1
-    this.fetchData(opt)
+    this.fetchData(this.viewOption)
   }
 
   gotoNextPage () {
     this.currentPage = this.currentPage + 1
-    this.fetchData(opt)
+    this.fetchData(this.viewOption)
   }
 
   fetchData (display) {
@@ -210,7 +212,7 @@ export default class extends Controller {
 
   setActiveOptionBtn (opt, optTargets) {
     optTargets.forEach(li => {
-      if (li.dataset.option === opt) {
+      if (li.dataset.option === this.viewOption) {
         li.classList.add('active')
       } else {
         li.classList.remove('active')

--- a/web/public/app/src/controllers/pow_controller.js
+++ b/web/public/app/src/controllers/pow_controller.js
@@ -3,7 +3,6 @@ import axios from 'axios'
 import { hide, show, legendFormatter, options } from '../utils'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
-var opt = 'table'
 
 export default class extends Controller {
   static get targets () {
@@ -15,9 +14,13 @@ export default class extends Controller {
     ]
   }
 
+  initialize () {
+    this.viewOption = 'table'
+  }
+
   setTable () {
-    opt = 'table'
-    this.setActiveOptionBtn(opt, this.viewOptionTargets)
+    this.viewOption = 'table'
+    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     this.chartWrapperTarget.classList.add('d-hide')
     this.powTableWrapperTarget.classList.remove('d-hide')
     this.numPageWrapperTarget.classList.remove('d-hide')
@@ -26,10 +29,10 @@ export default class extends Controller {
   }
 
   setChart () {
-    opt = 'chart'
+    this.viewOption = 'chart'
     this.numPageWrapperTarget.classList.add('d-hide')
     this.powTableWrapperTarget.classList.add('d-hide')
-    this.setActiveOptionBtn(opt, this.viewOptionTargets)
+    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     this.chartWrapperTarget.classList.remove('d-hide')
     this.nextPage = 1
     this.fetchExchange('chart')
@@ -37,22 +40,22 @@ export default class extends Controller {
 
   loadPreviousPage () {
     this.nextPage = this.previousPageButtonTarget.getAttribute('data-next-page')
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   loadNextPage () {
     this.nextPage = this.nextPageButtonTarget.getAttribute('data-next-page')
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   selectedFilterChanged () {
     this.nextPage = 1
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   NumberOfRowsChanged () {
     this.nextPage = 1
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   fetchExchange (display) {
@@ -122,7 +125,7 @@ export default class extends Controller {
       dataSet.push(data)
       data = []
     })
-    console.log(dataSet)
+
     var extra = {
       labels: ['Date', 'Pool Hashrate'],
       colors: ['#2971FF', '#FF8C00'],
@@ -141,7 +144,7 @@ export default class extends Controller {
 
   setActiveOptionBtn (opt, optTargets) {
     optTargets.forEach(li => {
-      if (li.dataset.option === opt) {
+      if (li.dataset.option === this.viewOption) {
         li.classList.add('active')
       } else {
         li.classList.remove('active')

--- a/web/public/app/src/controllers/vsp_controller.js
+++ b/web/public/app/src/controllers/vsp_controller.js
@@ -157,6 +157,7 @@ export default class extends Controller {
 
   // vsp chart
   plotGraph (dataSet) {
+    const _this = this
     dataSet = Object.values(dataSet)
     let yLabel = this.graphTypeTarget.value.split('_').join(' ')
     // let labels = ['Date', this.selectedFilterTarget.value]
@@ -182,34 +183,33 @@ export default class extends Controller {
         }
       }
     }
-    console.log(minDate, maxDate)
-    const _this = this
+    let options = {
+      legend: 'always',
+      includeZero: true,
+      dateWindow: [minDate, maxDate],
+      animatedZooms: true,
+      legendFormatter: legendFormatter,
+      plotter: barChartPlotter,
+      labelsDiv: _this.labelsTarget,
+      ylabel: yLabel,
+      xlabel: 'Date',
+      labelsUTC: true,
+      labelsKMB: true,
+      axes: {
+        x: {
+          drawGrid: false
+        }
+      }
+    }
+    switch (this.graphTypeTarget.value) {
+      case 'Immature':
+
+        break
+    }
     _this.chartsView = new Dygraph(
       _this.chartsViewTarget,
       csv,
-      {
-        legend: 'always',
-        // title: title,
-        includeZero: true,
-        dateWindow: [minDate, maxDate],
-        animatedZooms: true,
-        legendFormatter: legendFormatter,
-        plotter: barChartPlotter,
-        labelsDiv: _this.labelsTarget,
-        ylabel: yLabel,
-        xlabel: 'Date',
-        labelsUTC: true,
-        labelsKMB: true,
-        maxNumberWidth: 10,
-        axes: {
-          x: {
-            drawGrid: false
-          },
-          y: {
-            axisLabelWidth: 90
-          }
-        }
-      }
+      options
     )
   }
 

--- a/web/public/app/src/controllers/vsp_controller.js
+++ b/web/public/app/src/controllers/vsp_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from 'stimulus'
 import axios from 'axios'
-import { hide, show, legendFormatter, options } from '../utils'
+import { hide, show, legendFormatter, barChartPlotter } from '../utils'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
 
@@ -158,36 +158,58 @@ export default class extends Controller {
   // vsp chart
   plotGraph (dataSet) {
     dataSet = Object.values(dataSet)
+    let yLabel = this.graphTypeTarget.value.split('_').join(' ')
+    // let labels = ['Date', this.selectedFilterTarget.value]
+    // let colors = ['#007BFF']
+
+    let csv = `Date,${yLabel}\n`
+    let minDate, maxDate
+
     for (let i = 0; i < dataSet.length; i++) {
       if (!Array.isArray(dataSet[i])) continue
       for (let j = 0; j < dataSet[i].length; j++) {
         if (j === 0) {
-          dataSet[i][j] = new Date(dataSet[i][j])
+          const date = new Date(dataSet[i][j])
+          if (minDate === undefined || date < minDate) {
+            minDate = date
+          }
+          if (maxDate === undefined || date > maxDate) {
+            maxDate = date
+          }
+          csv += `${date},`
         } else if (!isNaN(dataSet[i][j])) {
-          dataSet[i][j] = parseFloat(dataSet[i][j])
+          csv += `${dataSet[i][j]}\n`
         }
       }
     }
-
-    let labels = ['Date', this.selectedFilterTarget.value]
-    let colors = ['#007BFF']
-
-    let yLabel = this.graphTypeTarget.value.split('_').join(' ')
-    var extra = {
-      legendFormatter: legendFormatter,
-      labelsDiv: this.labelsTarget,
-      ylabel: yLabel,
-      sigFigs: 8,
-      maxNumberWidth: 8,
-      labels: labels,
-      colors: colors
-    }
-
+    console.log(minDate, maxDate)
     const _this = this
-
     _this.chartsView = new Dygraph(
       _this.chartsViewTarget,
-      dataSet, { ...options, ...extra }
+      csv,
+      {
+        legend: 'always',
+        // title: title,
+        includeZero: true,
+        dateWindow: [minDate, maxDate],
+        animatedZooms: true,
+        legendFormatter: legendFormatter,
+        plotter: barChartPlotter,
+        labelsDiv: _this.labelsTarget,
+        ylabel: yLabel,
+        xlabel: 'Date',
+        labelsUTC: true,
+        labelsKMB: true,
+        maxNumberWidth: 10,
+        axes: {
+          x: {
+            drawGrid: false
+          },
+          y: {
+            axisLabelWidth: 90
+          }
+        }
+      }
     )
   }
 

--- a/web/public/app/src/controllers/vsp_controller.js
+++ b/web/public/app/src/controllers/vsp_controller.js
@@ -193,27 +193,13 @@ export default class extends Controller {
       legendFormatter: legendFormatter,
       labelsDiv: this.labelsTarget,
       ylabel: yLabel,
-      sigFigs: 1,
+      sigFigs: 16,
+      maxNumberWidth: 30,
       labels: labels,
       colors: colors
     }
 
     const _this = this
-
-    /* var data = []
-    var dataSet = []
-    vsps.forEach(vsp => {
-      data.push(new Date(vsp.time))
-      // data.push(vsp.pool_fees)
-      // data.push(vsp.immature)
-      // data.push(vsp.voted)
-      // data.push(vsp.missed)
-      data.push(vsp.proportion_live)
-      data.push(vsp.proportion_missed)
-
-      dataSet.push(data)
-      data = []
-    }) */
 
     _this.chartsView = new Dygraph(
       _this.chartsViewTarget,

--- a/web/public/app/src/controllers/vsp_controller.js
+++ b/web/public/app/src/controllers/vsp_controller.js
@@ -160,6 +160,10 @@ export default class extends Controller {
     const _this = this
     dataSet = Object.values(dataSet)
     let yLabel = this.graphTypeTarget.value.split('_').join(' ')
+    if ((yLabel.toLowerCase() === 'proportion live' || yLabel.toLowerCase() === 'proportion missed')) {
+      yLabel += ' (%)'
+    }
+
     // let labels = ['Date', this.selectedFilterTarget.value]
     // let colors = ['#007BFF']
 

--- a/web/public/app/src/controllers/vsp_controller.js
+++ b/web/public/app/src/controllers/vsp_controller.js
@@ -3,7 +3,6 @@ import axios from 'axios'
 import { hide, show, legendFormatter, options } from '../utils'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
-var opt = 'table'
 
 export default class extends Controller {
   static get targets () {
@@ -21,11 +20,12 @@ export default class extends Controller {
     if (this.currentPage < 1) {
       this.currentPage = 1
     }
+    this.viewOption = 'table'
   }
 
   setTable () {
-    this.opt = 'table'
-    this.setActiveOptionBtn(this.opt, this.viewOptionTargets)
+    this.viewOption = 'table'
+    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     hide(this.chartWrapperTarget)
     hide(this.graphTypeWrapperTarget)
     show(this.vspTableWrapperTarget)
@@ -36,37 +36,37 @@ export default class extends Controller {
   }
 
   setChart () {
-    this.opt = 'chart'
+    this.viewOption = 'chart'
     hide(this.numPageWrapperTarget)
     hide(this.vspTableWrapperTarget)
     show(this.graphTypeWrapperTarget)
     show(this.chartWrapperTarget)
-    this.setActiveOptionBtn(this.opt, this.viewOptionTargets)
+    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     this.nextPage = 1
     if (this.selectedFilterTarget.selectedIndex === 0) {
-      this.selectedFilterTarget.value = this.selectedFilterTarget.options[1].text
+      this.selectedFilterTarget.selectedIndex = 1
     }
     this.fetchExchange('chart')
   }
 
   loadPreviousPage () {
     this.nextPage = this.previousPageButtonTarget.getAttribute('data-next-page')
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   loadNextPage () {
     this.nextPage = this.nextPageButtonTarget.getAttribute('data-next-page')
     this.totalPages = (this.nextPageButtonTarget.getAttribute('data-total-page'))
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   selectedFilterChanged () {
-    if (this.opt === 'table') {
+    if (this.viewOption === 'table') {
       this.nextPage = 1
-      this.fetchExchange(opt)
+      this.fetchExchange(this.viewOption)
     } else {
-      if (this.selectedFilterTarget.value === 'All') {
-        this.selectedFilterTarget.value = this.selectedFilterTarget.options[1].text
+      if (this.selectedFilterTarget.selectedIndex === 0) {
+        this.selectedFilterTarget.selectedIndex = 1
       }
       this.fetchDataAndGraph()
     }
@@ -74,7 +74,7 @@ export default class extends Controller {
 
   numberOfRowsChanged () {
     this.nextPage = 1
-    this.fetchExchange(opt)
+    this.fetchExchange(this.viewOption)
   }
 
   fetchExchange (display) {
@@ -193,7 +193,7 @@ export default class extends Controller {
 
   setActiveOptionBtn (opt, optTargets) {
     optTargets.forEach(li => {
-      if (li.dataset.option === opt) {
+      if (li.dataset.option === this.viewOption) {
         li.classList.add('active')
       } else {
         li.classList.remove('active')

--- a/web/public/app/src/utils.js
+++ b/web/public/app/src/utils.js
@@ -42,6 +42,10 @@ export function legendFormatter (data) {
       if (!series.isVisible) return nodes
       let yVal = series.yHTML
       yVal = series.y
+      // propotion missed/live has % sign
+      if ((series.label.toLowerCase() === 'proportion live (%)' || series.label.toLowerCase() === 'proportion missed (%)')) {
+        yVal += '%'
+      }
 
       return `${nodes} <div class="pr-2">${series.dashHTML} ${series.labelHTML}: ${yVal}</div>`
     }, '')

--- a/web/public/app/src/utils.js
+++ b/web/public/app/src/utils.js
@@ -92,7 +92,7 @@ function darkenColor (colorStr) {
 }
 
 export var options = {
-  axes: { y: { axisLabelWidth: 70 } },
+  axes: { y: { axisLabelWidth: 100 } },
   axisLabelFontSize: 12,
   // digitsAfterDecimal: 8,
   retainDateWindow: false,

--- a/web/public/app/src/utils.js
+++ b/web/public/app/src/utils.js
@@ -94,7 +94,7 @@ function darkenColor (colorStr) {
 export var options = {
   axes: { y: { axisLabelWidth: 70 } },
   axisLabelFontSize: 12,
-  digitsAfterDecimal: 8,
+  // digitsAfterDecimal: 8,
   retainDateWindow: false,
   showRangeSelector: true,
   rangeSelectorHeight: 40,

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -36,20 +36,20 @@
 
                 <div class="row align-items-center">
                     <div class="col-md-4 col-sm-12 mb-2">
-                        <div class="control-label">Source:</div>
+                        <div class="control-label">VSP:</div>
                         <select data-target="vsp.selectedFilter" data-action="change->vsp#selectedFilterChanged"
                             class="form-control" style="width: 278px;">
                             {{$selectedFilter := .selectedFilter}}
                             <option value="All">All</option>
 
                             {{ range $index, $filter := .allVspData}}
-                            <option value="{{$filter.Name}}" {{ if eq $filter.Name $selectedFilter}} selected {{ end }}>{{$filter.Name}} ({{$filter.URL}})</option>
+                            <option value="{{$filter.Name}}" {{ if eq $filter.Name $selectedFilter}} selected {{ end }}>{{$filter.Host}} ({{$filter.Name}})</option>
                             {{ end }}
                         </select>
                     </div>
 
                     <div data-target="vsp.graphTypeWrapper" class="col-md-3 col-sm-12 mb-2 d-none ">
-                        <div class="control-label">Attribute:</div>
+                        <div class="control-label">Data:</div>
                         <select data-target="vsp.graphType" data-action="change->vsp#graphTypeChanged"
                             class="form-control" style="width: 150px;">
                             <option value="Immature">Immature</option>

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -35,15 +35,15 @@
                 </div>
 
                 <div class="row align-items-center">
-                    <div class="col-md-3 col-sm-12 mb-2">
+                    <div class="col-md-4 col-sm-12 mb-2">
                         <div class="control-label">Source:</div>
                         <select data-target="vsp.selectedFilter" data-action="change->vsp#selectedFilterChanged"
-                            class="form-control" style="width: 110px;">
+                            class="form-control" style="width: 278px;">
                             {{$selectedFilter := .selectedFilter}}
                             <option value="All">All</option>
 
                             {{ range $index, $filter := .allVspData}}
-                            <option value="{{$filter.Name}}" {{ if eq $filter.Name $selectedFilter}} selected {{ end }}>{{$filter.Name}}</option>
+                            <option value="{{$filter.Name}}" {{ if eq $filter.Name $selectedFilter}} selected {{ end }}>{{$filter.Name}} ({{$filter.URL}})</option>
                             {{ end }}
                         </select>
                     </div>

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -34,8 +34,8 @@
                     </div>
                 </div>
 
-                <div class="row align-items-center justify-content-between">
-                    <div data-target="vsp.selectedFilterWrapper" class="col-md-4 col-sm-12 mb-2">
+                <div class="row align-items-center">
+                    <div class="col-md-3 col-sm-12 mb-2">
                         <div class="control-label">Source:</div>
                         <select data-target="vsp.selectedFilter" data-action="change->vsp#selectedFilterChanged"
                             class="form-control" style="width: 110px;">
@@ -67,8 +67,8 @@
                     <div class="col-sm-7 d-none" data-target="vsp.chartSourceWrapper">
                         {{ range $index, $filter := .allVspData}}
                         <div class="form-check form-check-inline">
-                            <input data-target="vsp.chartSource" data-action="click->vsp#chartSourceCheckChanged"
-                            class="form-check-input" type="checkbox" id="inlineCheckbox-{{$filter.Name}}"
+                            <input name="chartSource" data-target="vsp.chartSource" data-action="click->vsp#chartSourceCheckChanged"
+                            class="form-check-input" type="radio" id="inlineCheckbox-{{$filter.Name}}"
                             value="{{$filter.Name}}" {{ if eq $index 0 }} checked {{ end }}>
                             <label class="form-check-label" for="inlineCheckbox-{{$filter.Name}}">{{$filter.Name}}</label>
                         </div>


### PR DESCRIPTION
Fixes #89, fixes #97, fixes #94 
Updated and shortened VSP ticks log.
Increased number width for the y-axis of the VSP chart.
And modified `VSP` chart to allow the plotting of one graph at a time.
Show proportion live/missed as percentages on the VSP chart.
Used bar chart for plotting all VSP chart.
Show host URL for all VSP sources.

![image](https://user-images.githubusercontent.com/11990092/61729099-6d1aee00-ad6e-11e9-8a12-07400498ab77.png)
