### PR TITLE
Remove extra selector on mempool chart

### DIFF
--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -49,7 +49,6 @@ export default class extends Controller {
     this.chartFilter = this.selectedMempoolOptTarget.value = y[0].value
     this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     show(this.chartDataTypeSelectorTarget)
-    show(this.chartOptionsTarget)
     hide(this.numPageWrapperTarget)
     show(this.chartWrapperTarget)
     this.nextPage = 1

--- a/web/public/app/src/css/style.scss
+++ b/web/public/app/src/css/style.scss
@@ -441,6 +441,11 @@ table.collapsible .labels tr td {
   border-radius: 3px;
 }
 
+.mempool-control {
+  margin-left: 25px;
+  margin-bottom: 30px;
+}
+
 .form-control {
   display: inline-block;
   font-size: 0.8rem;

--- a/web/views/mempool.html
+++ b/web/views/mempool.html
@@ -45,8 +45,9 @@
                                 <option value="number_of_transactions">Number of Transactions</option>
                             </select>
                         </div>
+
                         <div class="chart-control-wrapper control-div p-0 d-none" data-target="mempool.chartDataTypeSelector">
-                            <div class="chart-control">
+                            <div class="chart-control mempool-control">
                                 <ul class="nav nav-pills">
                                     <li class="nav-item">
                                         <a
@@ -78,6 +79,7 @@
                                 </ul>
                             </div>
                         </div>
+
                         <div data-target="mempool.numPageWrapper" class="control-div p-0 ml-auto">
                             <div class="control-label">Page Size:</div>
 
@@ -109,7 +111,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div >
                     <div data-target="mempool.tableWrapper">
                         <table class="table">


### PR DESCRIPTION
Removes extra duplicate middle option.

![mempool-chart](https://user-images.githubusercontent.com/5521110/61834821-415f3d00-ae2e-11e9-9f37-3a1581333d97.png)
