### PR TITLE
VSP chart

### DIFF
--- a/postgres/vsp.go
+++ b/postgres/vsp.go
@@ -117,7 +117,7 @@ func responseToVSPTick(poolID int, resp *vsp.ResposeData) *models.VSPTick {
 }
 
 func (pg *PgDb) FetchVSPs(ctx context.Context) ([]vsp.VSPDto, error) {
-	vspData, err := models.VSPS().All(ctx, pg.db)
+	vspData, err := models.VSPS(qm.OrderBy(models.VSPColumns.URL), qm.OrderBy(models.VSPColumns.Name)).All(ctx, pg.db)
 	if err != nil {
 		return nil, err
 	}

--- a/vsp/types.go
+++ b/vsp/types.go
@@ -81,6 +81,6 @@ func (err PoolTickTimeExistsError) Error() string {
 type ChartPoints []interface{}
 
 type ChartData struct {
-	Date   time.Time
-	Record string
+	Date   time.Time `json:"date"`
+	Record string    `json:"record"`
 }

--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -92,7 +92,7 @@ func (vsp *Collector) Run(ctx context.Context) {
 		for {
 			select {
 			case <-ctx.Done():
-				log.Infof("Shutting VSP down collector")
+				log.Infof("Shutting down VSP collector")
 				return
 			case <-ticker.C:
 				// continually check the state of the app until its free to run this module

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -6,9 +6,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
-	"strings"
-	"time"
-
+	
 	"github.com/raedahgroup/dcrextdata/exchanges/ticks"
 	"github.com/raedahgroup/dcrextdata/vsp"
 )
@@ -304,59 +302,15 @@ func (s *Server) getFilteredVspTicks(res http.ResponseWriter, req *http.Request)
 // vspchartdata
 func (s *Server) vspChartData(res http.ResponseWriter, req *http.Request) {
 	req.ParseForm()
-	sources := req.FormValue("sources")
+	vsp := req.FormValue("vsp")
 	selectedAttribute := req.FormValue("selectedAttribute")
 
-	vsps := strings.Split(sources, "|")
-
-	ctx := context.Background()
-	dates, err := s.db.GetVspTickDistinctDates(ctx, vsps)
+	points, err := s.db.FetchChartData(req.Context(), selectedAttribute, vsp)
 	if err != nil {
-		s.renderErrorJSON(fmt.Sprintf("Error is getting dates from VSP table, %s", err.Error()), res)
-		return
+		s.renderErrorJSON(fmt.Sprintf("Error in fetching VSP chart data for %s, %s", vsp, err.Error()), res)
 	}
 
-	var resultMap = map[time.Time][]interface{}{}
-	for _, date := range dates {
-		resultMap[date] = []interface{}{date}
-	}
-
-	for _, source := range vsps {
-		points, err := s.db.FetchChartData(ctx, selectedAttribute, source)
-		if err != nil {
-			s.renderErrorJSON(fmt.Sprintf("Error in fetching %s records for %s: %s", selectedAttribute, source, err.Error()), res)
-			return
-		}
-
-		var vspPointMap = map[time.Time]interface{}{}
-		for _, point := range points {
-			vspPointMap[point.Date] = point.Record
-		}
-
-		//var previousDate time.Time
-		for date, _ := range resultMap {
-			if record, found := vspPointMap[date]; found {
-				resultMap[date] = append(resultMap[date], record)
-				//previousDate = date
-			} else {
-				resultMap[date] = append(resultMap[date], 0)
-				/*if record, found := vspPointMap[previousDate]; found {
-					resultMap[date] = append(resultMap[date], record)
-				} else {
-					fmt.Println(fmt.Sprintf("not found and %s not seen before", previousDate.String()))
-					resultMap[date] = append(resultMap[date], 0)
-				}*/
-			}
-		}
-	}
-
-	/*
-		var chartData [][]interface{}
-		for _, points := range resultMap {
-			chartData = append(chartData, points)
-		}*/
-
-	s.renderJSON(resultMap, res)
+	s.renderJSON(points, res)
 }
 
 // /PoW

--- a/web/public/app/src/controllers/vsp_controller.js
+++ b/web/public/app/src/controllers/vsp_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from 'stimulus'
 import axios from 'axios'
-import { hide, show, legendFormatter, barChartPlotter } from '../utils'
+import { hide, show, legendFormatter } from '../utils'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
 
@@ -11,6 +11,7 @@ export default class extends Controller {
       'previousPageButton', 'totalPageCount', 'nextPageButton',
       'vspRowTemplate', 'currentPage', 'selectedNum', 'vspTableWrapper',
       'graphTypeWrapper', 'graphType', 'pageSizeWrapper',
+      'vspSelectorWrapper', 'chartSourceWrapper', 'chartSource',
       'chartWrapper', 'labels', 'chartsView', 'viewOption'
     ]
   }
@@ -28,6 +29,13 @@ export default class extends Controller {
       this.currentPage = 1
     }
     this.viewOption = 'table'
+
+    this.vsps = []
+    this.chartSourceTargets.forEach(chartSource => {
+      if (chartSource.checked) {
+        this.vsps.push(chartSource.value)
+      }
+    })
   }
 
   setTable () {
@@ -35,9 +43,11 @@ export default class extends Controller {
     this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     hide(this.chartWrapperTarget)
     hide(this.graphTypeWrapperTarget)
+    hide(this.chartSourceWrapperTarget)
     show(this.vspTableWrapperTarget)
     show(this.numPageWrapperTarget)
     show(this.pageSizeWrapperTarget)
+    show(this.vspSelectorWrapperTarget)
     this.vspTicksTableTarget.innerHTML = ''
     this.nextPage = 1
     this.fetchExchange('table')
@@ -47,8 +57,10 @@ export default class extends Controller {
     this.viewOption = 'chart'
     hide(this.numPageWrapperTarget)
     hide(this.vspTableWrapperTarget)
+    hide(this.vspSelectorWrapperTarget)
     show(this.graphTypeWrapperTarget)
     show(this.chartWrapperTarget)
+    show(this.chartSourceWrapperTarget)
     hide(this.pageSizeWrapperTarget)
     this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     this.nextPage = 1
@@ -77,7 +89,7 @@ export default class extends Controller {
       if (this.selectedFilterTarget.selectedIndex === 0) {
         this.selectedFilterTarget.selectedIndex = 1
       }
-      this.fetchDataAndGraph()
+      this.fetchDataAndPlotGraph()
     }
   }
 
@@ -90,7 +102,7 @@ export default class extends Controller {
     const selectedFilter = this.selectedFilterTarget.value
     var numberOfRows
     if (display === 'chart') {
-      this.fetchDataAndGraph()
+      this.fetchDataAndPlotGraph()
       return
     } else {
       numberOfRows = this.selectedNumTarget.value
@@ -152,16 +164,34 @@ export default class extends Controller {
     })
   }
 
-  fetchDataAndGraph () {
-    let _this = this
-    let url = `/vspchartdata?selectedAttribute=${this.graphTypeTarget.value}&vsp=${this.selectedFilterTarget.value}`
-    axios.get(url).then(function (response) {
-      _this.plotGraph(response.data)
+  chartSourceCheckChanged (event) {
+    this.vsps = []
+    this.chartSourceTargets.forEach(chartSource => {
+      if (chartSource.checked) {
+        this.vsps.push(chartSource.value)
+      }
     })
+    const element = event.currentTarget
+    if (this.vsps.length === 0 && !element.checked) {
+      element.checked = true
+      this.vsps.push(element.value)
+    }
+    this.fetchDataAndPlotGraph()
   }
 
   graphTypeChanged () {
-    this.fetchDataAndGraph()
+    this.fetchDataAndPlotGraph()
+  }
+
+  fetchDataAndPlotGraph () {
+    if (this.vsps.length === 0) {
+      return
+    }
+    let _this = this
+    let url = `/vspchartdata?selectedAttribute=${this.graphTypeTarget.value}&vsps=${this.vsps.join('|')}`
+    axios.get(url).then(function (response) {
+      _this.plotGraph(response.data)
+    })
   }
 
   // vsp chart
@@ -172,36 +202,19 @@ export default class extends Controller {
       yLabel += ' (%)'
     }
 
-    // let labels = ['Date', this.selectedFilterTarget.value]
-    // let colors = ['#007BFF']
-
-    let csv = `Date,${yLabel}\n`
-    let minDate, maxDate
-
-    dataSet.forEach(point => {
-      const date = new Date(point.date)
-      if (date.getFullYear() === 1970) return
-      if (minDate === undefined || date < minDate) {
-        minDate = date
-      }
-      if (maxDate === undefined || date > maxDate) {
-        maxDate = date
-      }
-      csv += `${date},${point.record}\n`
-    })
-
     let options = {
       legend: 'always',
       includeZero: true,
-      dateWindow: [minDate, maxDate],
+      // dateWindow: [dataSet.min_date, dataSet.max_date],
       animatedZooms: true,
       legendFormatter: legendFormatter,
-      plotter: barChartPlotter,
+      // plotter: barChartPlotter,
       labelsDiv: _this.labelsTarget,
       ylabel: yLabel,
       xlabel: 'Date',
       labelsUTC: true,
       labelsKMB: true,
+      connectSeparatedPoints: true,
       axes: {
         x: {
           drawGrid: false
@@ -215,7 +228,7 @@ export default class extends Controller {
     }
     _this.chartsView = new Dygraph(
       _this.chartsViewTarget,
-      csv,
+      dataSet.csv,
       options
     )
   }

--- a/web/public/app/src/controllers/vsp_controller.js
+++ b/web/public/app/src/controllers/vsp_controller.js
@@ -154,7 +154,7 @@ export default class extends Controller {
 
   fetchDataAndGraph () {
     let _this = this
-    let url = `/vspchartdata?selectedAttribute=${this.graphTypeTarget.value}&sources=${this.selectedFilterTarget.value}`
+    let url = `/vspchartdata?selectedAttribute=${this.graphTypeTarget.value}&vsp=${this.selectedFilterTarget.value}`
     axios.get(url).then(function (response) {
       _this.plotGraph(response.data)
     })
@@ -167,7 +167,6 @@ export default class extends Controller {
   // vsp chart
   plotGraph (dataSet) {
     const _this = this
-    dataSet = Object.values(dataSet)
     let yLabel = this.graphTypeTarget.value.split('_').join(' ')
     if ((yLabel.toLowerCase() === 'proportion live' || yLabel.toLowerCase() === 'proportion missed')) {
       yLabel += ' (%)'
@@ -179,23 +178,18 @@ export default class extends Controller {
     let csv = `Date,${yLabel}\n`
     let minDate, maxDate
 
-    for (let i = 0; i < dataSet.length; i++) {
-      if (!Array.isArray(dataSet[i])) continue
-      for (let j = 0; j < dataSet[i].length; j++) {
-        if (j === 0) {
-          const date = new Date(dataSet[i][j])
-          if (minDate === undefined || date < minDate) {
-            minDate = date
-          }
-          if (maxDate === undefined || date > maxDate) {
-            maxDate = date
-          }
-          csv += `${date},`
-        } else if (!isNaN(dataSet[i][j])) {
-          csv += `${dataSet[i][j]}\n`
-        }
+    dataSet.forEach(point => {
+      const date = new Date(point.date)
+      if (date.getFullYear() === 1970) return
+      if (minDate === undefined || date < minDate) {
+        minDate = date
       }
-    }
+      if (maxDate === undefined || date > maxDate) {
+        maxDate = date
+      }
+      csv += `${date},${point.record}\n`
+    })
+
     let options = {
       legend: 'always',
       includeZero: true,

--- a/web/public/app/src/css/style.scss
+++ b/web/public/app/src/css/style.scss
@@ -428,6 +428,20 @@ table.collapsible .labels tr td {
   padding-right: 0.2rem;
 }
 
+.side-vsp-panel {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 23%;
+  flex: 0 0 23%;
+  max-width: 23%;
+}
+
+.chart-panel {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 77%;
+  flex: 0 0 77%;
+  max-width: 77%;
+}
+
 .chart-control {
   background: #fff;
   width: max-content;

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -9,9 +9,7 @@
                 <div class="control-wrapper">
                     <div class="chart-control-wrapper mb-2" data-target="vsp.chartSelector">
                         <div class="chart-control">
-                            <ul
-                            class="nav nav-pills"
-                            >
+                            <ul class="nav nav-pills">
                             <li class="nav-item">
                                 <a
                                 class="nav-link active"
@@ -35,7 +33,7 @@
                 </div>
 
                 <div class="d-flex flex-row">
-                    <div class="control-div p-0">
+                    <div class="control-div p-0" data-target="vsp.vspSelectorWrapper">
                         <div class="control-label">VSP:</div>
                         <select data-target="vsp.selectedFilter" data-action="change->vsp#selectedFilterChanged"
                             class="form-control" style="width: 278px;">
@@ -64,17 +62,6 @@
                         </select>
                     </div>
 
-                    <div class="control-div p-0 d-none" data-target="vsp.chartSourceWrapper">
-                        {{ range $index, $filter := .allVspData}}
-                        <div class="form-check form-check-inline">
-                            <input name="chartSource" data-target="vsp.chartSource" data-action="click->vsp#chartSourceCheckChanged"
-                            class="form-check-input" type="radio" id="inlineCheckbox-{{$filter.Name}}"
-                            value="{{$filter.Name}}" {{ if eq $index 0 }} checked {{ end }}>
-                            <label class="form-check-label" for="inlineCheckbox-{{$filter.Name}}">{{$filter.Name}}</label>
-                        </div>
-                        {{ end }}
-                    </div>
-
                     <div data-target="vsp.numPageWrapper" class="control-div p-0 ml-auto">
                         <div class=" mb-2 float-md-right">
                             <div class="control-label">Page Size:</div>
@@ -96,25 +83,26 @@
                         </div>
                     </div>
                 </div>
+
             <div class="" data-target="vsp.vspTableWrapper">
                 <table class="table">
                     <thead>
-                        <tr>
-                            <th>VSP</th>
-                            <th>Immature</th>
-                            <th>Live</th>
-                            <th>Voted</th>
-                            <th>Missed</th>
-                            <th>Pool Fees</th>
-                            <th>% Live</th>
-                            <th>% Missed</th>
-                            <th>User Count</th>
-                            <th>Users Active</th>
-                            <th>Time(UTC)</th>
-                        </tr>
+                    <tr>
+                        <th>VSP</th>
+                        <th>Immature</th>
+                        <th>Live</th>
+                        <th>Voted</th>
+                        <th>Missed</th>
+                        <th>Pool Fees</th>
+                        <th>% Live</th>
+                        <th>% Missed</th>
+                        <th>User Count</th>
+                        <th>Users Active</th>
+                        <th>Time(UTC)</th>
+                    </tr>
                     </thead>
                     <tbody data-target="vsp.vspTicksTable">
-                        {{range $index, $vspticks := .vspData}}
+                    {{range $index, $vspticks := .vspData}}
                         <tr>
                             <td>{{$vspticks.VSP}}</td>
                             <td>{{$vspticks.Immature}}</td>
@@ -128,7 +116,7 @@
                             <td>{{$vspticks.UsersActive}}</td>
                             <td>{{$vspticks.Time}}</td>
                         </tr>
-                        {{end}}
+                    {{end}}
                     </tbody>
                 </table>
 
@@ -150,9 +138,27 @@
             </div>
 
             <div data-target="vsp.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-none">
-                <div id="chart"
-                data-target="vsp.chartsView"
-                style="width:100%; height:73vh; margin:0 auto;">
+                <div class="row">
+                    <div class="col-sm-3 side-vsp-panel">
+                        <div class="p-0 d-none" data-target="vsp.chartSourceWrapper">
+                            {{ range $index, $filter := .allVspData}}
+                                <div class="form-check form-check-inline">
+                                    <input name="chartSource" data-target="vsp.chartSource" data-action="click->vsp#chartSourceCheckChanged"
+                                           class="form-check-input" type="checkbox" id="inlineCheckbox-{{$filter.Name}}"
+                                           value="{{$filter.Name}}" {{ if eq $index 0 }} checked {{ end }}>
+                                    <label class="form-check-label" for="inlineCheckbox-{{$filter.Name}}">{{$filter.Host}} ({{$filter.Name}})</label>
+                                </div>
+                            {{ end }}
+                        </div>
+                    </div>
+
+                    <div class="col-md-9 chart-panel">
+                        <div id="chart"
+                             data-target="vsp.chartsView"
+                             style="width:100%; height:73vh; margin:0 auto;">
+                    </div>
+                </div>
+
             </div>
             <div class="d-flex justify-content-center legend-wrapper">
                 <div class="legend d-flex" data-target="vsp.labels"></div>


### PR DESCRIPTION
In this PR, VSP chart is plotted using lines in place of the formally used bars.
The ability to view the graph of multiple VSP at the same time is added.
The issue of wrong date label observed for some sources in the previous chart was resolved.
Also resolved is an issue observed when some combination of the VSPs is viewed on a single chart.
The VSP selector panel was also moved to the letf.

![image](https://user-images.githubusercontent.com/11990092/61844874-f6c6da80-ae98-11e9-88d3-3593c94cf25b.png)

