### PR TITLE
Add pow charts

### DIFF
--- a/web/public/app/src/controllers/pow_controller.js
+++ b/web/public/app/src/controllers/pow_controller.js
@@ -37,13 +37,14 @@ export default class extends Controller {
     hide(this.chartDataTypeSelectorTarget)
     this.nextPage = 1
     this.fetchExchange('table')
-    document.getElementById('page-s').innerHTML = 'Page Size:'
+    $('[value="20"]').prop('selected', true)
   }
 
   setChart () {
+    $('[value="150"]').prop('selected', true)
     this.viewOption = 'chart'
     this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
-    show(this.numPageWrapperTarget)
+    hide(this.numPageWrapperTarget)
     hide(this.powTableWrapperTarget)
     show(this.chartWrapperTarget)
     hide(this.pageSizeWrapperTarget)
@@ -51,7 +52,6 @@ export default class extends Controller {
     // hide(this.numPageWrapperTarget)
     this.nextPage = 1
     this.fetchExchange('chart')
-    document.getElementById('page-s').innerHTML = 'Size:'
   }
 
   setHashrateDataType (event) {
@@ -233,7 +233,8 @@ export default class extends Controller {
         labelsDiv: this.labelsTarget,
         ylabel: dataTypeLabel,
         y2label: 'Network Difficulty',
-        sigFigs: 1,
+        xlabel: 'Date',
+        labelsKMB: true,
         legendFormatter: legendFormatter
       }
 
@@ -269,7 +270,7 @@ export default class extends Controller {
         ylabel: dataTypeLabel,
         y2label: 'Network Difficulty',
         xlabel: 'Date',
-        sigFigs: 1,
+        labelsKMB: true,
         legendFormatter: legendFormatter
       }
 

--- a/web/public/app/src/controllers/pow_controller.js
+++ b/web/public/app/src/controllers/pow_controller.js
@@ -37,12 +37,13 @@ export default class extends Controller {
     hide(this.chartDataTypeSelectorTarget)
     this.nextPage = 1
     this.fetchExchange('table')
+    document.getElementById('page-s').innerHTML = 'Page Size:'
   }
 
   setChart () {
     this.viewOption = 'chart'
     this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
-    hide(this.numPageWrapperTarget)
+    show(this.numPageWrapperTarget)
     hide(this.powTableWrapperTarget)
     show(this.chartWrapperTarget)
     hide(this.pageSizeWrapperTarget)
@@ -50,6 +51,7 @@ export default class extends Controller {
     // hide(this.numPageWrapperTarget)
     this.nextPage = 1
     this.fetchExchange('chart')
+    document.getElementById('page-s').innerHTML = 'Size:'
   }
 
   setHashrateDataType (event) {
@@ -150,38 +152,132 @@ export default class extends Controller {
 
     var data = []
     var dataSet = []
-    pows.forEach(pow => {
-      data.push(new Date(pow.time))
 
-      if (_this.dataType === 'hashrate') {
-        data.push(parseInt(pow.pool_hashrate_th))
-      } else {
-        data.push(parseInt(pow.workers))
+    if (this.selectedFilterTarget.value === 'All') {
+    // init states for chartDataTypeSelector
+      var dat = []
+      dat[0] = 0 // not used
+      dat[1] = 0 // luxor
+      dat[2] = 0 // uupool
+      dat[3] = 0 // btc
+      dat[4] = 0 // f2pool
+      dat[5] = 0 // coinmine
+
+      // create unique dates
+      var lastDate
+
+      pows.forEach(pow => {
+        if (pow.source === 'luxor') {
+          if (_this.dataType === 'hashrate') {
+            dat[1] = parseInt(pow.pool_hashrate_th)
+          } else {
+            dat[1] = parseInt(pow.workers)
+          }
+        } else if (pow.source === 'uupool') {
+          if (_this.dataType === 'hashrate') {
+            dat[2] = parseInt(pow.pool_hashrate_th)
+          } else {
+            dat[2] = parseInt(pow.workers)
+          }
+        } else if (pow.source === 'btc') {
+          if (_this.dataType === 'hashrate') {
+            dat[3] = parseInt(pow.pool_hashrate_th)
+          } else {
+            dat[3] = parseInt(pow.workers)
+          }
+        } else if (pow.source === 'f2pool') {
+          if (_this.dataType === 'hashrate') {
+            dat[4] = parseInt(pow.pool_hashrate_th)
+          } else {
+            dat[4] = parseInt(pow.workers)
+          }
+        } else if (pow.source === 'coinmine') {
+          if (_this.dataType === 'hashrate') {
+            dat[5] = parseInt(pow.pool_hashrate_th)
+          } else {
+            dat[5] = parseInt(pow.workers)
+          }
+        }
+
+        data.push(new Date(pow.time))
+        data.push(dat[1])
+        data.push(dat[2])
+        data.push(dat[3])
+        data.push(dat[4])
+        data.push(dat[5])
+
+        // if same as last date  update and fill in missing values
+        // eg row 33 = btc 13340000 0 2019-07-26 17:44
+        //    row 34 = coinmine 1 960 2019-07-26 17:44
+        // then combine to one dataset row
+        /* eslint-disable brace-style */
+        if (lastDate === new Date(pow.time)) {
+          dataSet.splice(dataSet.length, 1, data)
+        }
+
+        // else push to new date dataset row
+        else {
+          dataSet.push(data)
+        }
+        data = []
+      })
+
+      let dataTypeLabel = 'Pool Hashrate'
+      if (_this.dataType === 'workers') {
+        dataTypeLabel = 'Workers'
       }
 
-      dataSet.push(data)
-      data = []
-    })
+      var extra = {
+        labels: ['Date', 'luxor', 'uupool', 'btc', 'f2pool', 'coinmine'],
+        colors: ['#2971FF', '#FF8C00', '#64FFDA', '#84FFFF', '#EEFF41', '#FFCCBC'],
+        labelsDiv: this.labelsTarget,
+        ylabel: dataTypeLabel,
+        y2label: 'Network Difficulty',
+        sigFigs: 1,
+        legendFormatter: legendFormatter
+      }
 
-    let dataTypeLabel = 'Pool Hashrate'
-    if (_this.dataType === 'workers') {
-      dataTypeLabel = 'Workers'
+      _this.chartsView = new Dygraph(
+        _this.chartsViewTarget,
+        dataSet,
+        { ...options, ...extra }
+      )
+    } else {
+      pows.forEach(pow => {
+        data.push(new Date(pow.time))
+
+        if (_this.dataType === 'hashrate') {
+          data.push(parseInt(pow.pool_hashrate_th))
+        } else {
+          data.push(parseInt(pow.workers))
+        }
+
+        dataSet.push(data)
+        data = []
+      })
+
+      let dataTypeLabel = 'Pool Hashrate'
+      if (_this.dataType === 'workers') {
+        dataTypeLabel = 'Workers'
+      }
+
+      /* eslint-disable no-redeclare */
+      var extra = {
+        labels: ['Date', dataTypeLabel],
+        colors: ['#2971FF', '#FF8C00'],
+        labelsDiv: this.labelsTarget,
+        ylabel: dataTypeLabel,
+        y2label: 'Network Difficulty',
+        xlabel: 'Date',
+        sigFigs: 1,
+        legendFormatter: legendFormatter
+      }
+
+      _this.chartsView = new Dygraph(
+        _this.chartsViewTarget,
+        dataSet, { ...options, ...extra }
+      )
     }
-
-    var extra = {
-      labels: ['Date', dataTypeLabel],
-      colors: ['#2971FF', '#FF8C00'],
-      labelsDiv: this.labelsTarget,
-      ylabel: dataTypeLabel,
-      y2label: 'Network Difficulty',
-      sigFigs: 1,
-      legendFormatter: legendFormatter
-    }
-
-    _this.chartsView = new Dygraph(
-      _this.chartsViewTarget,
-      dataSet, { ...options, ...extra }
-    )
   }
 
   setActiveOptionBtn (opt, optTargets) {

--- a/web/public/app/src/controllers/pow_controller.js
+++ b/web/public/app/src/controllers/pow_controller.js
@@ -10,12 +10,14 @@ export default class extends Controller {
       'selectedFilter', 'powTable', 'numPageWrapper',
       'previousPageButton', 'totalPageCount', 'nextPageButton',
       'powRowTemplate', 'currentPage', 'selectedNum', 'powTableWrapper',
-      'chartWrapper', 'labels', 'chartsView', 'viewOption', 'pageSizeWrapper'
+      'chartWrapper', 'chartDataTypeSelector', 'chartDataType', 'labels',
+      'chartsView', 'viewOption', 'pageSizeWrapper'
     ]
   }
 
   initialize () {
     this.viewOption = 'table'
+    this.dataType = 'hashrate'
   }
 
   connect () {
@@ -32,6 +34,7 @@ export default class extends Controller {
     show(this.powTableWrapperTarget)
     show(this.numPageWrapperTarget)
     show(this.pageSizeWrapperTarget)
+    hide(this.chartDataTypeSelectorTarget)
     this.nextPage = 1
     this.fetchExchange('table')
   }
@@ -43,7 +46,27 @@ export default class extends Controller {
     hide(this.powTableWrapperTarget)
     show(this.chartWrapperTarget)
     hide(this.pageSizeWrapperTarget)
+    show(this.chartDataTypeSelectorTarget)
+    // hide(this.numPageWrapperTarget)
     this.nextPage = 1
+    this.fetchExchange('chart')
+  }
+
+  setHashrateDataType (event) {
+    this.dataType = 'hashrate'
+    this.chartDataTypeTargets.forEach(el => {
+      el.classList.remove('active')
+    })
+    event.currentTarget.classList.add('active')
+    this.fetchExchange('chart')
+  }
+
+  setWorkersDataType (event) {
+    this.dataType = 'workers'
+    this.chartDataTypeTargets.forEach(el => {
+      el.classList.remove('active')
+    })
+    event.currentTarget.classList.add('active')
     this.fetchExchange('chart')
   }
 
@@ -128,18 +151,28 @@ export default class extends Controller {
     var data = []
     var dataSet = []
     pows.forEach(pow => {
-      data.push(new Date(pow.Time))
-      data.push(pow.pool_hashrate_th)
+      data.push(new Date(pow.time))
+
+      if (_this.dataType === 'hashrate') {
+        data.push(parseInt(pow.pool_hashrate_th))
+      } else {
+        data.push(parseInt(pow.workers))
+      }
 
       dataSet.push(data)
       data = []
     })
 
+    let dataTypeLabel = 'Pool Hashrate'
+    if (_this.dataType === 'workers') {
+      dataTypeLabel = 'Workers'
+    }
+
     var extra = {
-      labels: ['Date', 'Pool Hashrate'],
+      labels: ['Date', dataTypeLabel],
       colors: ['#2971FF', '#FF8C00'],
       labelsDiv: this.labelsTarget,
-      ylabel: 'Pool Hashrate',
+      ylabel: dataTypeLabel,
       y2label: 'Network Difficulty',
       sigFigs: 1,
       legendFormatter: legendFormatter

--- a/web/views/pow.html
+++ b/web/views/pow.html
@@ -45,6 +45,32 @@
                         {{ end }}
                     </select>
                 </div>
+
+                <div class="chart-control-wrapper control-div p-0 d-none" data-target="pow.chartDataTypeSelector">
+                    <div class="chart-control mempool-control">
+                        <ul class="nav nav-pills">
+                            <li class="nav-item">
+                                <a
+                                data-target="pow.chartDataType"
+                                data-action="click->pow#setHashrateDataType"
+                                class="nav-link active"
+                                href="javascript:void(0);"
+                                data-option="table"
+                                >Hashrate</a>
+                            </li>
+                            <li class="nav-item">
+                                <a
+                                data-target="pow.chartDataType"
+                                data-action="click->pow#setWorkersDataType"
+                                class="nav-link"
+                                href="javascript:void(0);"
+                                data-option="table"
+                                >Workers</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+
                 <div data-target="pow.numPageWrapper" class="control-div p-0 ml-auto">
                     <div class=" mb-2 float-md-right">
                         <div class="control-label">Page Size:</div>
@@ -61,7 +87,7 @@
                             <a href="javascript:void(0)" data-target="pow.previousPageButton" data-action="click->pow#loadPreviousPage" data-next-page="{{ .previousPage }}" class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
 
                             <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="pow.currentPage" class="text-muted"> {{ .currentPage }}</span> of <span data-target="pow.totalPageCount" class="text-muted">{{ .totalPages }}</span>
-                            </p>    
+                            </p>
                             <a href="javascript:void(0)" data-target="pow.nextPageButton" data-action="click->pow#loadNextPage" data-total-page="{{ .totalPages }}" data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}"> Next&gt;</a>
                 </div>
             </div>

--- a/web/views/pow.html
+++ b/web/views/pow.html
@@ -73,7 +73,7 @@
 
                 <div data-target="pow.numPageWrapper" class="control-div p-0 ml-auto">
                     <div class=" mb-2 float-md-right">
-                        <div class="control-label">Page Size:</div>
+                        <div id="page-s" class="control-label">Page Size:</div>
                         <select data-target="pow.selectedNum" data-action="change->pow#numberOfRowsChanged" class="form-control mr-5" style="width: 70px;">
                             <option value="20" selected>20</option>
                             <option value="30">30</option>


### PR DESCRIPTION
Addresses #90 

Brings back PoW chart.

![powchart0](https://user-images.githubusercontent.com/5521110/61916593-f44a9c00-aefd-11e9-84d4-8e01aee9ac4f.png)

The other charts make sense 
![pow-screen](https://user-images.githubusercontent.com/5521110/61916669-44296300-aefe-11e9-9bce-457edcfb99f1.png)

but the main one doesn't should I remove the _All_ selector?

