### PR TITLE
logging of the new collection cycle time

### DIFF
--- a/pow/collectors.go
+++ b/pow/collectors.go
@@ -111,8 +111,8 @@ func (pc *Collector) CollectAsync(ctx context.Context) {
 			}
 			completeCollectionCycle := pc.store.LastPowEntryTime("")
 			collectionCycleDate := time.Unix(completeCollectionCycle, 0)
-			timePassed := time.Since(collectionCycleDate)
-			log.Info("The next collection cycle begins in", timePassed)
+			timeInterval := time.Since(collectionCycleDate)
+			log.Info("The next collection cycle begins in", timeInterval)
 
 			log.Info("Starting a new PoW collection cycle")
 			pc.Collect(ctx)

--- a/pow/collectors.go
+++ b/pow/collectors.go
@@ -109,6 +109,10 @@ func (pc *Collector) CollectAsync(ctx context.Context) {
 					break
 				}
 			}
+			completeCollectionCycle := pc.store.LastPowEntryTime("")
+			collectionCycleDate := time.Unix(completeCollectionCycle, 0)
+			timePassed := time.Since(collectionCycleDate)
+			log.Info("The next collection cycle begins in", timePassed)
 
 			log.Info("Starting a new PoW collection cycle")
 			pc.Collect(ctx)


### PR DESCRIPTION
Closes #107 
The time duration between the last and the new collection cycles was missing. 

This is to log in the "exact" time it will take before the next collection cycle begins.
