### PR TITLE
# Added fix to make the tables and charts utilize available screen size, added some other fixes.

### DIFF
--- a/mempool/types.go
+++ b/mempool/types.go
@@ -75,6 +75,11 @@ type VoteDto struct {
 	Validity              string `json:"validity"`
 }
 
+type PropagationChartData struct {
+	BlockHeight    int64 `json:"block_height"`
+	TimeDifference float64  `json:"time_difference"`
+}
+
 type DataStore interface {
 	StoreMempool(context.Context, Mempool) error
 	LastMempoolTime() (entryTime time.Time, err error)

--- a/sample-dcrextdata.conf
+++ b/sample-dcrextdata.conf
@@ -17,7 +17,7 @@
 ; Authentication information for dcrd RPC (dcrdrpcserver is already set just un-comment by removing the semi-colon)
 ;dcrdrpcserver = 127.0.0.1:9109
 ;dcrdrpcuser = rpcuser
-;dcrdrpcpaswword = rpcpass
+;dcrdrpcpassword = rpcpass
 
 ; Values 0 = false, 1 = true
 ; Disable exchangeTicks data collection

--- a/web/public/app/src/controllers/exchange_controller.js
+++ b/web/public/app/src/controllers/exchange_controller.js
@@ -23,11 +23,11 @@ export default class extends Controller {
     this.selectedFilterTarget.value = filter[0].text
     this.selectedCurrencyPairTarget.value = cpair[0].text
     this.selectedNumTarget.value = num[0].text
-    this.selectedIntervalTarget.value = interval[0].value
+    this.selectedIntervalTarget.value = interval[4].value
   }
 
   initialize () {
-    this.viewOption = 'table'
+    this.setChart()
     this.selectedFilter = this.selectedFilterTarget.value
     this.selectedCurrencyPair = this.selectedCurrencyPairTarget.value
 
@@ -55,7 +55,7 @@ export default class extends Controller {
     this.selectedFilter = this.selectedFilterTarget.value = filter[0].text
     this.selectedCurrencyPair = this.selectedCurrencyPairTarget.value = cpair[0].text
     this.selectedNum = this.selectedNumTarget.value = num[0].value
-    this.selectedInterval = this.selectedIntervalTarget.value = interval[0].value
+    this.selectedInterval = this.selectedIntervalTarget.value = interval[4].value
     this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     this.selectedTicksTarget.value = 'close'
     this.nextPage = 1
@@ -76,7 +76,7 @@ export default class extends Controller {
     hide(this.numPageWrapperTarget)
     hide(this.exchangeTableWrapperTarget)
     this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
-    this.selectedInterval = this.selectedIntervalTarget.value = interval[1].value
+    this.selectedInterval = this.selectedIntervalTarget.value = interval[4].value
     this.selectedFilter = this.selectedFilterTarget.value = sFilter[1].text
     this.selectedTick = this.selectedTicksTarget.value = 'close'
     this.selectedCurrencyPair = this.selectedCurrencyPairTarget.value = 'BTC/DCR'

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -26,7 +26,7 @@ export default class extends Controller {
       this.currentPage = 1
     }
     this.dataType = 'size'
-    this.viewOption = 'table'
+    this.setChart()
   }
 
   setTable () {

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from 'stimulus'
 import axios from 'axios'
-import { legendFormatter, barChartPlotter, hide, show } from '../utils'
+import { legendFormatter, barChartPlotter, hide, show, setActiveOptionBtn } from '../utils'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
 
@@ -31,7 +31,7 @@ export default class extends Controller {
 
   setTable () {
     this.viewOption = 'table'
-    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
+    setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     hide(this.chartWrapperTarget)
     hide(this.chartDataTypeSelectorTarget)
     show(this.tableWrapperTarget)
@@ -47,7 +47,7 @@ export default class extends Controller {
     hide(this.tableWrapperTarget)
     var y = this.selectedMempoolOptTarget.options
     this.chartFilter = this.selectedMempoolOptTarget.value = y[0].value
-    this.setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
+    setActiveOptionBtn(this.viewOption, this.viewOptionTargets)
     show(this.chartDataTypeSelectorTarget)
     hide(this.numPageWrapperTarget)
     show(this.chartWrapperTarget)
@@ -227,15 +227,5 @@ export default class extends Controller {
         }
       }
     )
-  }
-
-  setActiveOptionBtn (opt, optTargets) {
-    optTargets.forEach(li => {
-      if (li.dataset.option === this.viewOption) {
-        li.classList.add('active')
-      } else {
-        li.classList.remove('active')
-      }
-    })
   }
 }

--- a/web/public/app/src/controllers/pow_controller.js
+++ b/web/public/app/src/controllers/pow_controller.js
@@ -15,7 +15,7 @@ export default class extends Controller {
   }
 
   initialize () {
-    this.viewOption = 'table'
+    this.setChart()
   }
 
   connect () {

--- a/web/public/app/src/controllers/pow_controller.js
+++ b/web/public/app/src/controllers/pow_controller.js
@@ -128,8 +128,9 @@ export default class extends Controller {
     var data = []
     var dataSet = []
     pows.forEach(pow => {
-      data.push(new Date(pow.Time))
-      data.push(pow.pool_hashrate_th)
+      pow.time = this.formatPowDateTime(pow.time)
+      data.push(new Date(pow.time))
+      data.push(Number(pow.pool_hashrate_th))
 
       dataSet.push(data)
       data = []
@@ -159,5 +160,11 @@ export default class extends Controller {
         li.classList.remove('active')
       }
     })
+  }
+
+  formatPowDateTime (dateTime) {
+    // dateTime is coming in format yy-mm-dd hh:mm
+    // Date method expects format yy-mm-ddThh:mm:ss
+    return (dateTime + ':00').split(' ').join('T')
   }
 }

--- a/web/public/app/src/controllers/pow_controller.js
+++ b/web/public/app/src/controllers/pow_controller.js
@@ -128,9 +128,8 @@ export default class extends Controller {
     var data = []
     var dataSet = []
     pows.forEach(pow => {
-      pow.time = this.formatPowDateTime(pow.time)
-      data.push(new Date(pow.time))
-      data.push(Number(pow.pool_hashrate_th))
+      data.push(new Date(pow.Time))
+      data.push(pow.pool_hashrate_th)
 
       dataSet.push(data)
       data = []
@@ -160,11 +159,5 @@ export default class extends Controller {
         li.classList.remove('active')
       }
     })
-  }
-
-  formatPowDateTime (dateTime) {
-    // dateTime is coming in format yy-mm-dd hh:mm
-    // Date method expects format yy-mm-ddThh:mm:ss
-    return (dateTime + ':00').split(' ').join('T')
   }
 }

--- a/web/public/app/src/controllers/propagation_controller.js
+++ b/web/public/app/src/controllers/propagation_controller.js
@@ -25,12 +25,12 @@ export default class extends Controller {
   }
 
   initialize () {
+    this.setChart()
     this.currentPage = parseInt(this.currentPageTarget.getAttribute('data-current-page'))
     if (this.currentPage < 1) {
       this.currentPage = 1
     }
     this.selectedRecordSet = 'both'
-    this.setChart()
   }
 
   setTable () {

--- a/web/public/app/src/controllers/propagation_controller.js
+++ b/web/public/app/src/controllers/propagation_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
       this.currentPage = 1
     }
     this.selectedRecordSet = 'both'
-    this.viewOption = 'table'
+    this.setChart()
   }
 
   setTable () {

--- a/web/public/app/src/controllers/propagation_controller.js
+++ b/web/public/app/src/controllers/propagation_controller.js
@@ -160,21 +160,25 @@ export default class extends Controller {
     const _this = this
     this.votesTableBodyTarget.innerHTML = ''
 
-    data.forEach(item => {
-      const exRow = document.importNode(_this.votesRowTemplateTarget.content, true)
-      const fields = exRow.querySelectorAll('td')
+    if (data) {
+      data.forEach(item => {
+        const exRow = document.importNode(_this.votesRowTemplateTarget.content, true)
+        const fields = exRow.querySelectorAll('td')
 
-      fields[0].innerHTML = `<a target="_blank" href="https://explorer.dcrdata.org/block/${item.voting_on}">${item.voting_on}</a>`
-      fields[1].innerHTML = `<a target="_blank" href="https://explorer.dcrdata.org/block/${item.block_hash}">...${item.short_block_hash}</a>`
-      fields[2].innerText = item.validator_id
-      fields[3].innerText = item.validity
-      fields[4].innerText = item.receive_time
-      fields[5].innerText = item.block_time_diff
-      fields[6].innerText = item.block_receive_time_diff
-      fields[7].innerHTML = `<a target="_blank" href="https://explorer.dcrdata.org/tx/${item.hash}">${item.hash}</a>`
+        fields[0].innerHTML = `<a target="_blank" href="https://explorer.dcrdata.org/block/${item.voting_on}">${item.voting_on}</a>`
+        fields[1].innerHTML = `<a target="_blank" href="https://explorer.dcrdata.org/block/${item.block_hash}">...${item.short_block_hash}</a>`
+        fields[2].innerText = item.validator_id
+        fields[3].innerText = item.validity
+        fields[4].innerText = item.receive_time
+        fields[5].innerText = item.block_time_diff
+        fields[6].innerText = item.block_receive_time_diff
+        fields[7].innerHTML = `<a target="_blank" href="https://explorer.dcrdata.org/tx/${item.hash}">${item.hash}</a>`
 
-      _this.votesTableBodyTarget.appendChild(exRow)
-    })
+        _this.votesTableBodyTarget.appendChild(exRow)
+      })
+    } else {
+      this.votesTableBodyTarget.innerHTML = 'No votes to show'
+    }
 
     hide(this.tableTarget)
     hide(this.blocksTableTarget)

--- a/web/public/app/src/controllers/vsp_controller.js
+++ b/web/public/app/src/controllers/vsp_controller.js
@@ -28,7 +28,6 @@ export default class extends Controller {
     if (this.currentPage < 1) {
       this.currentPage = 1
     }
-    this.viewOption = 'table'
 
     this.vsps = []
     this.chartSourceTargets.forEach(chartSource => {
@@ -36,6 +35,7 @@ export default class extends Controller {
         this.vsps.push(chartSource.value)
       }
     })
+    this.setChart()
   }
 
   setTable () {

--- a/web/public/app/src/css/style.scss
+++ b/web/public/app/src/css/style.scss
@@ -405,7 +405,6 @@ table.collapsible .labels tr td {
 .control-div {
   padding: 0, 0, 0, 1rem !important;
   white-space: nowrap;
-  // display: inline-block;
   margin-right: 1rem;
 }
 

--- a/web/public/app/src/css/style.scss
+++ b/web/public/app/src/css/style.scss
@@ -448,7 +448,6 @@ table.collapsible .labels tr td {
 }
 
 .chart-control {
-  background: #fff;
   width: max-content;
   border-radius: 3px;
 }

--- a/web/public/app/src/css/style.scss
+++ b/web/public/app/src/css/style.scss
@@ -45,9 +45,14 @@ a:hover {
   padding-bottom: 0 !important;
 }
 
+.table {
+  width: auto !important;
+}
+
 .table td,
 .table th {
   padding: 0.3rem;
+  padding-right: 30px;
 }
 
 /* table */
@@ -400,7 +405,7 @@ table.collapsible .labels tr td {
 .control-div {
   padding: 0, 0, 0, 1rem !important;
   white-space: nowrap;
-  display: inline-block;
+  // display: inline-block;
   margin-right: 1rem;
 }
 
@@ -446,7 +451,6 @@ table.collapsible .labels tr td {
   background: #fff;
   width: max-content;
   border-radius: 3px;
-  display: inline-block;
 }
 
 .chart-control .nav-item {

--- a/web/public/app/src/css/style.scss
+++ b/web/public/app/src/css/style.scss
@@ -38,7 +38,7 @@ a:hover {
 }
 
 .content {
-  padding: 15px 0;
+  padding: 15px;
 }
 
 .no-btm-pad {

--- a/web/public/app/src/utils.js
+++ b/web/public/app/src/utils.js
@@ -118,3 +118,13 @@ export function getRandomColor () {
   }
   return color
 }
+
+export function setActiveOptionBtn (opt, optTargets) {
+  optTargets.forEach(li => {
+    if (li.dataset.option === opt) {
+      li.classList.add('active')
+    } else {
+      li.classList.remove('active')
+    }
+  })
+}

--- a/web/public/app/webpack/webpack.common.js
+++ b/web/public/app/webpack/webpack.common.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const StyleLintPlugin = require('stylelint-webpack-plugin')
-const webpack = require('webpack')
 
 module.exports = {
   entry: {
@@ -25,7 +24,7 @@ module.exports = {
           {
             // Interprets `@import` and `url()` like `import/require()` and will resolve them
             loader: 'css-loader'
-          },
+          }
         ]
       },
       {
@@ -53,9 +52,9 @@ module.exports = {
           {
             // Loads a SASS/SCSS file and compiles it to CSS
             loader: 'sass-loader'
-          },
+          }
         ]
-      },
+      }
     ]
   },
   plugins: [

--- a/web/server.go
+++ b/web/server.go
@@ -52,6 +52,8 @@ type DataQuery interface {
 
 	Votes(ctx context.Context, offset int, limit int) ([]mempool.VoteDto, error)
 	VotesCount(ctx context.Context) (int64, error)
+	PropagationVoteChartData(ctx context.Context) ([]mempool.PropagationChartData, error)
+	PropagationBlockChartData(ctx context.Context) ([]mempool.PropagationChartData, error)
 }
 
 type Server struct {
@@ -120,6 +122,7 @@ func (s *Server) registerHandlers(r *chi.Mux) {
 	r.Get("/getmempool", s.getMempool)
 	r.Get("/propagation", s.propagation)
 	r.Get("/getpropagationdata", s.getPropagationData)
+	r.Get("/propagationchartdata", s.propagationChartData)
 	r.Get("/getblocks", s.getBlocks)
 	r.Get("/getvotes", s.getVotes)
 }

--- a/web/views/error.html
+++ b/web/views/error.html
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 {{ template "html-head" }}
+
 <body>
-<div class="body">
-    {{ template "header" }}
-    <div class="content">
-        <div class="container text-center">
-            <h3 class="text-danger mb-3">Oops</h3>
-            <div class="alert alert-danger">{{ .error }}</div>
-            <p>Refresh or <a href="/">Go Home</a></p>
+    <div class="body">
+        {{ template "header" }}
+        <div class="content">
+            <div class="container-fluid text-center">
+                <h3 class="text-danger mb-3">Oops</h3>
+                <div class="alert alert-danger">{{ .error }}</div>
+                <p>Refresh or <a href="/">Go Home</a></p>
+            </div>
         </div>
     </div>
-</div>
 </body>

--- a/web/views/error.html
+++ b/web/views/error.html
@@ -9,7 +9,7 @@
             <div class="container-fluid text-center">
                 <h3 class="text-danger mb-3">Oops</h3>
                 <div class="alert alert-danger">{{ .error }}</div>
-                <p>Refresh or <a href="/">Go Home</a></p>
+                <p>Refresh or <a href="/">Return Home</a></p>
             </div>
         </div>
     </div>

--- a/web/views/exchange.html
+++ b/web/views/exchange.html
@@ -10,7 +10,7 @@
             <div class="container-fluid">
                 <div class="control-wrapper">
                     <div class="row chart-control-wrapper mb-2" data-target="exchange.chartSelector">
-                        <div class="chart-control">
+                        <div class="chart-control mx-auto">
                             <ul class="nav nav-pills">
                                 <li class="nav-item">
                                     <a class="nav-link active" href="javascript:void(0);"
@@ -26,84 +26,87 @@
                     </div>
 
                     <div class="d-flex flex-row bottom-ctl">
-                        <div class="control-div p-0">
-                            <div class="control-label">Currency Pair:</div>
-                            <select data-target="exchange.selectedCurrencyPair"
-                                data-action="change->exchange#selectedCurrencyPairChanged" class="form-control"
-                                style="width: 105px;">
-                                <option data-target="exchange.currencyPairHideOption" value="All">All</option>
-                                {{ range $index, $cpair := .currencyPairs}}
-                                <option value="{{$cpair.CurrencyPair}}">{{$cpair.CurrencyPair}}</option>
-                                {{ end }}
-                            </select>
-                        </div>
-                        <div data-target=exchange.sourceWrapper class="control-div p-0">
-                            <div class="control-label">Exchanges:</div>
-                            <select data-target="exchange.selectedFilter"
-                                data-action="change->exchange#selectedFilterChanged" class="form-control"
-                                style="width: 100px;">
-                                <option data-target="exchange.hideOption" value="All" selected>All</option>
-                                {{ range $index, $filter := .allExData}}
-                                <option value="{{$filter.Name}}">{{$filter.Name}}</option>
-                                {{ end }}
-                            </select>
-                        </div>
-                        <div data-target="exchange.intervalWapper" class="control-div p-0">
-                            <div class="control-label">Interval:</div>
-                            <select data-target="exchange.selectedInterval"
-                                data-action="change->exchange#selectedIntervalChanged" class="form-control"
-                                style="width: 60px;">
-                                <option data-target="exchange.hideIntervalOption" value="-1">All</option>
-                                <option value="5">5m</option>
-                                <option value="60">1h</option>
-                                <option value="120">2h</option>
-                                <option value="1440">1d</option>
-                            </select>
-                        </div>
+                        <div class="mx-auto d-flex my-2">
+                            <div class="control-div p-0">
+                                <div class="control-label">Currency Pair:</div>
+                                <select data-target="exchange.selectedCurrencyPair"
+                                    data-action="change->exchange#selectedCurrencyPairChanged" class="form-control"
+                                    style="width: 105px;">
+                                    <option data-target="exchange.currencyPairHideOption" value="All">All</option>
+                                    {{ range $index, $cpair := .currencyPairs}}
+                                    <option value="{{$cpair.CurrencyPair}}">{{$cpair.CurrencyPair}}</option>
+                                    {{ end }}
+                                </select>
+                            </div>
+                            <div data-target=exchange.sourceWrapper class="control-div p-0">
+                                <div class="control-label">Exchanges:</div>
+                                <select data-target="exchange.selectedFilter"
+                                    data-action="change->exchange#selectedFilterChanged" class="form-control"
+                                    style="width: 100px;">
+                                    <option data-target="exchange.hideOption" value="All" selected>All</option>
+                                    {{ range $index, $filter := .allExData}}
+                                    <option value="{{$filter.Name}}">{{$filter.Name}}</option>
+                                    {{ end }}
+                                </select>
+                            </div>
+                            <div data-target="exchange.intervalWapper" class="control-div p-0">
+                                <div class="control-label">Interval:</div>
+                                <select data-target="exchange.selectedInterval"
+                                    data-action="change->exchange#selectedIntervalChanged" class="form-control"
+                                    style="width: 60px;">
+                                    <option data-target="exchange.hideIntervalOption" value="-1">All</option>
+                                    <option value="5">5m</option>
+                                    <option value="60">1h</option>
+                                    <option value="120">2h</option>
+                                    <option value="1440">1d</option>
+                                </select>
+                            </div>
 
-                        <div data-target="exchange.tickWapper" class="control-div  p-0 d-hide">
-                            <div class="control-label">Data Ticks:</div>
-                            <select data-target="exchange.selectedTicks"
-                                data-action="change->exchange#selectedTicksChanged" class="form-control"
-                                style="width: 90px;">
-                                <option value="close">Close</option>
-                                <option value="high">High</option>
-                                <option value="open">Open</option>
-                                <option value="low">Low</option>
-                            </select>
-                        </div>
+                            <div data-target="exchange.tickWapper" class="control-div  p-0 d-hide">
+                                <div class="control-label">Data Ticks:</div>
+                                <select data-target="exchange.selectedTicks"
+                                    data-action="change->exchange#selectedTicksChanged" class="form-control"
+                                    style="width: 90px;">
+                                    <option value="close">Close</option>
+                                    <option value="high">High</option>
+                                    <option value="open">Open</option>
+                                    <option value="low">Low</option>
+                                </select>
+                            </div>
 
-                        <div data-target="exchange.numPageWrapper" class="control-div p-0 ml-auto">
-                            <div class="control-label">Page Size:</div>
-                            <select data-target="exchange.selectedNum"
-                                data-action="change->exchange#NumberOfRowsChanged" class="form-control"
-                                style="width: 70px;">
-                                <option value="20">20</option>
-                                <option value="30">30</option>
-                                <option value="50">50</option>
-                                <option value="100">100</option>
-                                <option value="150">150</option>
-                            </select>
-                        </div>
-                        <div data-target="exchange.pageSizeWrapper" class="d-flex">
-                            <a href="javascript:void(0)" data-target="exchange.previousPageButton"
-                                data-action="click->exchange#loadPreviousPage" data-previous-page="{{ .previousPage }}"
-                                data-current-page="{{ .totalPages }}"
-                                class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
+                            <div data-target="exchange.numPageWrapper" class="control-div p-0 ml-5">
+                                <div class="control-label">Page Size:</div>
+                                <select data-target="exchange.selectedNum"
+                                    data-action="change->exchange#NumberOfRowsChanged" class="form-control"
+                                    style="width: 70px;">
+                                    <option value="20">20</option>
+                                    <option value="30">30</option>
+                                    <option value="50">50</option>
+                                    <option value="100">100</option>
+                                    <option value="150">150</option>
+                                </select>
+                            </div>
+                            <div data-target="exchange.pageSizeWrapper" class="control-div pt-1">
+                                <a href="javascript:void(0)" data-target="exchange.previousPageButton"
+                                    data-action="click->exchange#loadPreviousPage" data-previous-page="{{ .previousPage }}"
+                                    data-current-page="{{ .totalPages }}"
+                                    class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
 
-                            <p class="text-muted" style="white-space: nowrap;"> Page <span
-                                    data-target="exchange.currentPage" class="text-muted"> {{ .currentPage }}</span> of
-                                <span data-target="exchange.totalPageCount" class="text-muted">{{ .totalPages }}</span>
-                            </p>
-                            <a href="javascript:void(0)" data-target="exchange.nextPageButton"
-                                data-action="click->exchange#loadNextPage" data-total-page="{{ .totalPages }}"
-                                data-current-page="{{ .totalPages }}" data-next-page="{{ .nextPage }}"
-                                class="ml-2 {{ if not .nextPage }}d-none{{ end }}"> Next&gt;</a>
+                                <p class="text-muted d-inline" style="white-space: nowrap;"> Page <span
+                                        data-target="exchange.currentPage" class="text-muted"> {{ .currentPage }}</span> of
+                                    <span data-target="exchange.totalPageCount" class="text-muted">{{ .totalPages }}</span>
+                                </p>
+                                <a href="javascript:void(0)" data-target="exchange.nextPageButton"
+                                    data-action="click->exchange#loadNextPage" data-total-page="{{ .totalPages }}"
+                                    data-current-page="{{ .totalPages }}" data-next-page="{{ .nextPage }}"
+                                    class="ml-2 {{ if not .nextPage }}d-none{{ end }}"> Next&gt;</a>
+                            </div>
                         </div>
+                        
                     </div>
                 </div>
                 <div class="" data-target="exchange.exchangeTableWrapper">
-                    <table class="table">
+                    <table class="table mx-auto">
                         <thead>
                             <tr style="white-space: nowrap;">
                                 <th>Time(UTC)</th>

--- a/web/views/exchange.html
+++ b/web/views/exchange.html
@@ -10,7 +10,7 @@
             <div class="container-fluid">
                 <div class="control-wrapper">
                     <div class="d-flex flex-row bottom-ctl">
-                        <div class="chart-control ml-auto mr-3">
+                        <div class="chart-control ml-auto mr-2 my-2">
                             <ul class="nav nav-pills">
                                 <li class="nav-item">
                                     <a class="nav-link active" href="javascript:void(0);" data-target="exchange.viewOption"
@@ -75,7 +75,7 @@
                                 </select>
                             </div>
 
-                            <div data-target="exchange.numPageWrapper" class="control-div p-0 ml-5">
+                            <div data-target="exchange.numPageWrapper" class="control-div p-0 ml-2">
                                 <div class="control-label">Page Size:</div>
                                 <select data-target="exchange.selectedNum"
                                     data-action="change->exchange#NumberOfRowsChanged" class="form-control"

--- a/web/views/exchange.html
+++ b/web/views/exchange.html
@@ -171,5 +171,4 @@
         </div>
         {{ template "footer" }}
 </body>
-
 </html>

--- a/web/views/exchange.html
+++ b/web/views/exchange.html
@@ -105,7 +105,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="d-hide" data-target="exchange.exchangeTableWrapper">
+                <div class="d-none" data-target="exchange.exchangeTableWrapper">
                     <table class="table mx-auto">
                         <thead>
                             <tr style="white-space: nowrap;">

--- a/web/views/exchange.html
+++ b/web/views/exchange.html
@@ -1,33 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
 {{ template "html-head" }}
+
 <body>
     <div class="body" data-controller="exchange">
 
         {{ template "header" }}
         <div class="content">
-            <div class="container">
+            <div class="container-fluid">
                 <div class="control-wrapper">
                     <div class="row chart-control-wrapper mb-2" data-target="exchange.chartSelector">
                         <div class="chart-control">
                             <ul class="nav nav-pills">
                                 <li class="nav-item">
-                                    <a
-                                    class="nav-link active"
-                                    href="javascript:void(0);"
-                                    data-target="exchange.viewOption"
-                                    data-action="click->exchange#setTable"
-                                    data-option="table"
-                                    >Table</a>
+                                    <a class="nav-link active" href="javascript:void(0);"
+                                        data-target="exchange.viewOption" data-action="click->exchange#setTable"
+                                        data-option="table">Table</a>
                                 </li>
                                 <li class="nav-item">
-                                    <a
-                                    class="nav-link"
-                                    href="javascript:void(0);"
-                                    data-target="exchange.viewOption"
-                                    data-action="click->exchange#setChart"
-                                    data-option="chart"
-                                    >Chart</a>
+                                    <a class="nav-link" href="javascript:void(0);" data-target="exchange.viewOption"
+                                        data-action="click->exchange#setChart" data-option="chart">Chart</a>
                                 </li>
                             </ul>
                         </div>
@@ -36,8 +28,9 @@
                     <div class="d-flex flex-row bottom-ctl">
                         <div class="control-div p-0">
                             <div class="control-label">Currency Pair:</div>
-                            <select data-target="exchange.selectedCurrencyPair" data-action="change->exchange#selectedCurrencyPairChanged"
-                                class="form-control" style="width: 105px;">
+                            <select data-target="exchange.selectedCurrencyPair"
+                                data-action="change->exchange#selectedCurrencyPairChanged" class="form-control"
+                                style="width: 105px;">
                                 <option data-target="exchange.currencyPairHideOption" value="All">All</option>
                                 {{ range $index, $cpair := .currencyPairs}}
                                 <option value="{{$cpair.CurrencyPair}}">{{$cpair.CurrencyPair}}</option>
@@ -46,8 +39,9 @@
                         </div>
                         <div data-target=exchange.sourceWrapper class="control-div p-0">
                             <div class="control-label">Exchanges:</div>
-                            <select data-target="exchange.selectedFilter" data-action="change->exchange#selectedFilterChanged"
-                                class="form-control" style="width: 100px;">
+                            <select data-target="exchange.selectedFilter"
+                                data-action="change->exchange#selectedFilterChanged" class="form-control"
+                                style="width: 100px;">
                                 <option data-target="exchange.hideOption" value="All" selected>All</option>
                                 {{ range $index, $filter := .allExData}}
                                 <option value="{{$filter.Name}}">{{$filter.Name}}</option>
@@ -56,8 +50,9 @@
                         </div>
                         <div data-target="exchange.intervalWapper" class="control-div p-0">
                             <div class="control-label">Interval:</div>
-                            <select data-target="exchange.selectedInterval" data-action="change->exchange#selectedIntervalChanged"
-                                class="form-control" style="width: 60px;">
+                            <select data-target="exchange.selectedInterval"
+                                data-action="change->exchange#selectedIntervalChanged" class="form-control"
+                                style="width: 60px;">
                                 <option data-target="exchange.hideIntervalOption" value="-1">All</option>
                                 <option value="5">5m</option>
                                 <option value="60">1h</option>
@@ -68,8 +63,9 @@
 
                         <div data-target="exchange.tickWapper" class="control-div  p-0 d-hide">
                             <div class="control-label">Data Ticks:</div>
-                            <select data-target="exchange.selectedTicks" data-action="change->exchange#selectedTicksChanged"
-                                class="form-control" style="width: 90px;">
+                            <select data-target="exchange.selectedTicks"
+                                data-action="change->exchange#selectedTicksChanged" class="form-control"
+                                style="width: 90px;">
                                 <option value="close">Close</option>
                                 <option value="high">High</option>
                                 <option value="open">Open</option>
@@ -79,7 +75,9 @@
 
                         <div data-target="exchange.numPageWrapper" class="control-div p-0 ml-auto">
                             <div class="control-label">Page Size:</div>
-                            <select data-target="exchange.selectedNum" data-action="change->exchange#NumberOfRowsChanged" class="form-control" style="width: 70px;">
+                            <select data-target="exchange.selectedNum"
+                                data-action="change->exchange#NumberOfRowsChanged" class="form-control"
+                                style="width: 70px;">
                                 <option value="20">20</option>
                                 <option value="30">30</option>
                                 <option value="50">50</option>
@@ -88,11 +86,19 @@
                             </select>
                         </div>
                         <div data-target="exchange.pageSizeWrapper" class="d-flex">
-                            <a href="javascript:void(0)" data-target="exchange.previousPageButton" data-action="click->exchange#loadPreviousPage" data-previous-page="{{ .previousPage }}" data-current-page="{{ .totalPages }}" class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
+                            <a href="javascript:void(0)" data-target="exchange.previousPageButton"
+                                data-action="click->exchange#loadPreviousPage" data-previous-page="{{ .previousPage }}"
+                                data-current-page="{{ .totalPages }}"
+                                class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
 
-                            <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="exchange.currentPage" class="text-muted"> {{ .currentPage }}</span> of <span data-target="exchange.totalPageCount" class="text-muted">{{ .totalPages }}</span>
-                            </p>    
-                            <a href="javascript:void(0)" data-target="exchange.nextPageButton" data-action="click->exchange#loadNextPage" data-total-page="{{ .totalPages }}" data-current-page="{{ .totalPages }}" data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}"> Next&gt;</a>
+                            <p class="text-muted" style="white-space: nowrap;"> Page <span
+                                    data-target="exchange.currentPage" class="text-muted"> {{ .currentPage }}</span> of
+                                <span data-target="exchange.totalPageCount" class="text-muted">{{ .totalPages }}</span>
+                            </p>
+                            <a href="javascript:void(0)" data-target="exchange.nextPageButton"
+                                data-action="click->exchange#loadNextPage" data-total-page="{{ .totalPages }}"
+                                data-current-page="{{ .totalPages }}" data-next-page="{{ .nextPage }}"
+                                class="ml-2 {{ if not .nextPage }}d-none{{ end }}"> Next&gt;</a>
                         </div>
                     </div>
                 </div>
@@ -161,5 +167,6 @@
             </div>
         </div>
         {{ template "footer" }}
-    </body>
-    </html>
+</body>
+
+</html>

--- a/web/views/exchange.html
+++ b/web/views/exchange.html
@@ -9,43 +9,44 @@
         <div class="content">
             <div class="container-fluid">
                 <div class="control-wrapper">
-                    <div class="row chart-control-wrapper mb-2" data-target="exchange.chartSelector">
-                        <div class="chart-control mx-auto">
+                    <div class="d-flex flex-row bottom-ctl">
+                        <div class="chart-control ml-auto mr-3">
                             <ul class="nav nav-pills">
                                 <li class="nav-item">
-                                    <a class="nav-link active" href="javascript:void(0);"
+                                    <a class="nav-link active" href="javascript:void(0);" data-target="exchange.viewOption"
+                                        data-action="click->exchange#setChart" data-option="chart">Chart</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="javascript:void(0);"
                                         data-target="exchange.viewOption" data-action="click->exchange#setTable"
                                         data-option="table">Table</a>
                                 </li>
-                                <li class="nav-item">
-                                    <a class="nav-link" href="javascript:void(0);" data-target="exchange.viewOption"
-                                        data-action="click->exchange#setChart" data-option="chart">Chart</a>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-
-                    <div class="d-flex flex-row bottom-ctl">
-                        <div class="mx-auto d-flex my-2">
+                        <div class="mr-auto d-flex my-2">
                             <div class="control-div p-0">
                                 <div class="control-label">Currency Pair:</div>
-                                <select data-target="exchange.selectedCurrencyPair"
+                                <select 
+                                    data-target="exchange.selectedCurrencyPair"
                                     data-action="change->exchange#selectedCurrencyPairChanged" class="form-control"
-                                    style="width: 105px;">
+                                    style="width: 105px;"
+                                >
                                     <option data-target="exchange.currencyPairHideOption" value="All">All</option>
                                     {{ range $index, $cpair := .currencyPairs}}
-                                    <option value="{{$cpair.CurrencyPair}}">{{$cpair.CurrencyPair}}</option>
+                                        <option value="{{$cpair.CurrencyPair}}">{{$cpair.CurrencyPair}}</option>
                                     {{ end }}
                                 </select>
                             </div>
                             <div data-target=exchange.sourceWrapper class="control-div p-0">
                                 <div class="control-label">Exchanges:</div>
-                                <select data-target="exchange.selectedFilter"
+                                <select 
+                                    data-target="exchange.selectedFilter"
                                     data-action="change->exchange#selectedFilterChanged" class="form-control"
-                                    style="width: 100px;">
+                                    style="width: 100px;"
+                                >
                                     <option data-target="exchange.hideOption" value="All" selected>All</option>
                                     {{ range $index, $filter := .allExData}}
-                                    <option value="{{$filter.Name}}">{{$filter.Name}}</option>
+                                        <option value="{{$filter.Name}}">{{$filter.Name}}</option>
                                     {{ end }}
                                 </select>
                             </div>
@@ -102,10 +103,9 @@
                                     class="ml-2 {{ if not .nextPage }}d-none{{ end }}"> Next&gt;</a>
                             </div>
                         </div>
-                        
                     </div>
                 </div>
-                <div class="" data-target="exchange.exchangeTableWrapper">
+                <div class="d-hide" data-target="exchange.exchangeTableWrapper">
                     <table class="table mx-auto">
                         <thead>
                             <tr style="white-space: nowrap;">
@@ -151,7 +151,7 @@
                         </tr>
                     </template>
                 </div>
-                <div data-target="exchange.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-hide">
+                <div data-target="exchange.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5">
                     <div id="chart" data-target="exchange.chartsView" style="width:100%; height:73vh; margin:0 auto;">
                     </div>
                     <div class="spinner-wrapper">

--- a/web/views/home.html
+++ b/web/views/home.html
@@ -12,5 +12,4 @@
     </div>
     {{ template "footer" }}
 </body>
-
 </html>

--- a/web/views/home.html
+++ b/web/views/home.html
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 {{ template "html-head" }}
+
 <body>
     <div class="body">
         {{ template "header" }}
         <div class="content">
-            <div class="container">
+            <div class="container-fluid">
             </div>
         </div>
     </div>
     {{ template "footer" }}
 </body>
+
 </html>

--- a/web/views/layout.html
+++ b/web/views/layout.html
@@ -37,13 +37,13 @@
             <div class="collapse navbar-collapse" id="nav">
                 <ul class="navbar-nav mx-auto">
                     <li class="nav-item">
-                        <a class="nav-link" id="nav-exchanges" href="/exchanges">
-                            <span class="text">Exchanges</span>
+                        <a class="nav-link" id="nav-mempool" href="/mempool">
+                            <span class="text">Mempool</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" id="nav-vsp" href="/vsp">
-                            <span class="text">VSPs</span>
+                        <a class="nav-link" id="nav-propagation" href="/propagation">
+                            <span class="text">Propagation</span>
                         </a>
                     </li>
                     <li class="nav-item">
@@ -52,13 +52,13 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" id="nav-mempool" href="/mempool">
-                            <span class="text">Mempool</span>
+                        <a class="nav-link" id="nav-vsp" href="/vsp">
+                            <span class="text">VSPs</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" id="nav-propagation" href="/propagation">
-                            <span class="text">Propagation</span>
+                        <a class="nav-link" id="nav-exchanges" href="/exchanges">
+                            <span class="text">Exchanges</span>
                         </a>
                     </li>
                 </ul>

--- a/web/views/layout.html
+++ b/web/views/layout.html
@@ -1,4 +1,5 @@
 {{ define "html-head" }}
+
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -8,13 +9,13 @@
     <meta name="author" content="The Decred developers">
     <title>dcrextdata</title>
 
-    <link rel="stylesheet" href="/static/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="/static/css/bootstrap.min.css" />
 
     <script src="/static/js/jquery.min.js"></script>
     <script src="/static/js/bootstrap.bundle.min.js"></script>
     <script src="/static/js/vendors~app.bundle.js"></script>
     <script src="/static/js/app.bundle.js?v={{ .timestamp }}"></script>
-    
+
 </head>
 {{ end }}
 
@@ -22,7 +23,7 @@
 <div class="header">
     <div class="header-top">
         <div class="inner">
-            <div class="container">
+            <div class="container-fluid">
                 <div class="text-center page-title">
                     <a href="/"> dcrextdata </a>
                 </div>
@@ -30,7 +31,7 @@
         </div>
     </div>
     <nav class="navbar navbar-expand-sm navbar-light bg-light">
-        <div class="container">
+        <div class="container-fluid">
             <button class="navbar-toggler" type="button" data-toggles="collapse" data-target="#nav">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -70,7 +71,7 @@
 
 {{ define "footer" }}
 <script>
-    $(function(){
+    $(function () {
         var pathname = window.location.pathname;
         var paths = pathname.split("/")
         var currentNavItem = "#nav-exchange";

--- a/web/views/layout.html
+++ b/web/views/layout.html
@@ -15,7 +15,6 @@
     <script src="/static/js/bootstrap.bundle.min.js"></script>
     <script src="/static/js/vendors~app.bundle.js"></script>
     <script src="/static/js/app.bundle.js?v={{ .timestamp }}"></script>
-
 </head>
 {{ end }}
 
@@ -36,7 +35,7 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="nav">
-                <ul class="navbar-nav mr-auto">
+                <ul class="navbar-nav mx-auto">
                     <li class="nav-item">
                         <a class="nav-link" id="nav-exchanges" href="/exchanges">
                             <span class="text">Exchanges</span>

--- a/web/views/mempool.html
+++ b/web/views/mempool.html
@@ -8,103 +8,107 @@
         <div class="content">
             <div class="container-fluid">
                 <div class="control-wrapper">
-                    <div class="d-block">
+                    <!-- <div class="d-block text-center">
                         <h4>Mempool</h4>
+                    </div> -->
+                    
+                    <div class="chart-control-wrapper mr-3 mb-3" data-target="mempool.chartSelector">
+                        <div class="chart-control mx-auto">
+                            <ul class="nav nav-pills">
+                                <li class="nav-item">
+                                    <a class="nav-link active" href="javascript:void(0);"
+                                        data-target="mempool.viewOption" data-action="click->mempool#setTable"
+                                        data-option="table">Table</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="javascript:void(0);" data-target="mempool.viewOption"
+                                        data-action="click->mempool#setChart" data-option="chart">Chart</a>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
                     <div class="d-flex flex-row">
-                        <div class="chart-control-wrapper mr-3" data-target="mempool.chartSelector">
-                            <div class="chart-control ">
-                                <ul class="nav nav-pills">
-                                    <li class="nav-item">
-                                        <a class="nav-link active" href="javascript:void(0);"
-                                            data-target="mempool.viewOption" data-action="click->mempool#setTable"
-                                            data-option="table">Table</a>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a class="nav-link" href="javascript:void(0);" data-target="mempool.viewOption"
-                                            data-action="click->mempool#setChart" data-option="chart">Chart</a>
-                                    </li>
-                                </ul>
+                        <div class="d-flex mx-auto">
+
+                            <div data-target="mempool.chartOptions" class="control-div p-0 d-hide">
+                                <div class="control-label ">Mempool Charts:</div>
+
+                                <select data-target="mempool.selectedMempoolOpt"
+                                    data-action="change->mempool#MempoolOptionChanged" class="form-control mr-5 "
+                                    style="width: 200px;">
+                                    <option value="size">Size Chart</option>
+                                    <option value="total_fee">Total fees Chart</option>
+                                    <option value="number_of_transactions">Number of Transactions</option>
+                                </select>
+                            </div>
+
+                            <div class="chart-control-wrapper control-div p-0 d-none"
+                                data-target="mempool.chartDataTypeSelector">
+                                <div class="chart-control mempool-control mx-auto">
+                                    <ul class="nav nav-pills">
+                                        <li class="nav-item">
+                                            <a data-target="mempool.chartDataType"
+                                                data-action="click->mempool#setSizeDataType" class="nav-link active"
+                                                href="javascript:void(0);" data-option="table">Size</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a data-target="mempool.chartDataType"
+                                                data-action="click->mempool#setFeesDataType" class="nav-link"
+                                                href="javascript:void(0);" data-option="table">Fees</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a data-target="mempool.chartDataType"
+                                                data-action="click->mempool#setTransactionsDataType" class="nav-link"
+                                                href="javascript:void(0);" data-option="table">Transactions</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <div data-target="mempool.numPageWrapper" class="control-div p-0">
+                                <div class="control-label">Page Size:</div>
+
+                                <select data-target="mempool.selectedNum" data-action="change->mempool#NumberOfRowsChanged"
+                                    class="form-control" style="width: 70px;">
+                                    <option value="20">20</option>
+                                    <option value="30">30</option>
+                                    <option value="50">50</option>
+                                    <option value="100">100</option>
+                                    <option value="150">150</option>
+                                </select>
+                            </div>
+                            <div class="d-flex">
+                                <div data-target="mempool.btnWrapper" class="float-md-right">
+                                    <button data-target="mempool.previousPageButton"
+                                        data-action="click->mempool#gotoPreviousPage"
+                                        data-previous-page="{{ .mempool.previousPage}}"
+                                        class="btn btn-link {{ if lt .mempool.previousPage 1 }}d-none{{ end }}">
+                                        &lt; Previous
+                                    </button>
+
+                                    <span data-target="mempool.pageReport" class="text-muted" style="white-space: nowrap;"
+                                        data-current-page="{{ .mempool.currentPage }}">
+                                        Page <span data-target="mempool.currentPage"
+                                            data-current-page="{{ .mempool.currentPage }}">{{ .mempool.currentPage }}</span>
+                                        of
+                                        <span data-target="mempool.totalPageCount">{{ .mempool.totalPages }}</span>
+                                    </span>
+
+                                    <button data-target="mempool.nextPageButton" data-action="click->mempool#gotoNextPage"
+                                        data-next-page="{{ .mempool.nextPage }}"
+                                        class="btn btn-link {{ if not .mempool.nextPage }}d-none{{ end }}">
+                                        Next &gt;
+                                    </button>
+                                </div>
                             </div>
                         </div>
-
-                        <div data-target="mempool.chartOptions" class="control-div p-0 d-hide">
-                            <div class="control-label ">Mempool Charts:</div>
-
-                            <select data-target="mempool.selectedMempoolOpt"
-                                data-action="change->mempool#MempoolOptionChanged" class="form-control mr-5 "
-                                style="width: 200px;">
-                                <option value="size">Size Chart</option>
-                                <option value="total_fee">Total fees Chart</option>
-                                <option value="number_of_transactions">Number of Transactions</option>
-                            </select>
-                        </div>
-
-                        <div class="chart-control-wrapper control-div p-0 d-none"
-                            data-target="mempool.chartDataTypeSelector">
-                            <div class="chart-control mempool-control">
-                                <ul class="nav nav-pills">
-                                    <li class="nav-item">
-                                        <a data-target="mempool.chartDataType"
-                                            data-action="click->mempool#setSizeDataType" class="nav-link active"
-                                            href="javascript:void(0);" data-option="table">Size</a>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a data-target="mempool.chartDataType"
-                                            data-action="click->mempool#setFeesDataType" class="nav-link"
-                                            href="javascript:void(0);" data-option="table">Fees</a>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a data-target="mempool.chartDataType"
-                                            data-action="click->mempool#setTransactionsDataType" class="nav-link"
-                                            href="javascript:void(0);" data-option="table">Transactions</a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-
-                        <div data-target="mempool.numPageWrapper" class="control-div p-0 ml-auto">
-                            <div class="control-label">Page Size:</div>
-
-                            <select data-target="mempool.selectedNum" data-action="change->mempool#NumberOfRowsChanged"
-                                class="form-control" style="width: 70px;">
-                                <option value="20">20</option>
-                                <option value="30">30</option>
-                                <option value="50">50</option>
-                                <option value="100">100</option>
-                                <option value="150">150</option>
-                            </select>
-                        </div>
-                        <div class="d-flex">
-                            <div data-target="mempool.btnWrapper" class="float-md-right">
-                                <button data-target="mempool.previousPageButton"
-                                    data-action="click->mempool#gotoPreviousPage"
-                                    data-previous-page="{{ .mempool.previousPage}}"
-                                    class="btn btn-link {{ if lt .mempool.previousPage 1 }}d-none{{ end }}">
-                                    &lt; Previous
-                                </button>
-
-                                <span data-target="mempool.pageReport" class="text-muted" style="white-space: nowrap;"
-                                    data-current-page="{{ .mempool.currentPage }}">
-                                    Page <span data-target="mempool.currentPage"
-                                        data-current-page="{{ .mempool.currentPage }}">{{ .mempool.currentPage }}</span>
-                                    of
-                                    <span data-target="mempool.totalPageCount">{{ .mempool.totalPages }}</span>
-                                </span>
-
-                                <button data-target="mempool.nextPageButton" data-action="click->mempool#gotoNextPage"
-                                    data-next-page="{{ .mempool.nextPage }}"
-                                    class="btn btn-link {{ if not .mempool.nextPage }}d-none{{ end }}">
-                                    Next &gt;
-                                </button>
-                            </div>
-                        </div>
+                        
                     </div>
                 </div>
 
                 <div>
                     <div data-target="mempool.tableWrapper">
-                        <table class="table">
+                        <table class="table mx-auto">
                             <thead>
                                 <tr>
                                     <th>Date (UTC)</th>

--- a/web/views/mempool.html
+++ b/web/views/mempool.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 {{ template "html-head" }}
+
 <body data-controller="receive">
     <div class="body" data-controller="mempool">
         {{ template "header" }}
         <div class="content">
-            <div class="container">
+            <div class="container-fluid">
                 <div class="control-wrapper">
                     <div class="d-block">
                         <h4>Mempool</h4>
@@ -15,22 +16,13 @@
                             <div class="chart-control ">
                                 <ul class="nav nav-pills">
                                     <li class="nav-item">
-                                        <a
-                                        class="nav-link active"
-                                        href="javascript:void(0);"
-                                        data-target="mempool.viewOption"
-                                        data-action="click->mempool#setTable"
-                                        data-option="table"
-                                        >Table</a>
+                                        <a class="nav-link active" href="javascript:void(0);"
+                                            data-target="mempool.viewOption" data-action="click->mempool#setTable"
+                                            data-option="table">Table</a>
                                     </li>
                                     <li class="nav-item">
-                                        <a
-                                        class="nav-link"
-                                        href="javascript:void(0);"
-                                        data-target="mempool.viewOption"
-                                        data-action="click->mempool#setChart"
-                                        data-option="chart"
-                                        >Chart</a>
+                                        <a class="nav-link" href="javascript:void(0);" data-target="mempool.viewOption"
+                                            data-action="click->mempool#setChart" data-option="chart">Chart</a>
                                     </li>
                                 </ul>
                             </div>
@@ -39,42 +31,33 @@
                         <div data-target="mempool.chartOptions" class="control-div p-0 d-hide">
                             <div class="control-label ">Mempool Charts:</div>
 
-                            <select data-target="mempool.selectedMempoolOpt" data-action="change->mempool#MempoolOptionChanged" class="form-control mr-5 " style="width: 200px;">
+                            <select data-target="mempool.selectedMempoolOpt"
+                                data-action="change->mempool#MempoolOptionChanged" class="form-control mr-5 "
+                                style="width: 200px;">
                                 <option value="size">Size Chart</option>
                                 <option value="total_fee">Total fees Chart</option>
                                 <option value="number_of_transactions">Number of Transactions</option>
                             </select>
                         </div>
 
-                        <div class="chart-control-wrapper control-div p-0 d-none" data-target="mempool.chartDataTypeSelector">
+                        <div class="chart-control-wrapper control-div p-0 d-none"
+                            data-target="mempool.chartDataTypeSelector">
                             <div class="chart-control mempool-control">
                                 <ul class="nav nav-pills">
                                     <li class="nav-item">
-                                        <a
-                                        data-target="mempool.chartDataType"
-                                        data-action="click->mempool#setSizeDataType"
-                                        class="nav-link active"
-                                        href="javascript:void(0);"
-                                        data-option="table"
-                                        >Size</a>
+                                        <a data-target="mempool.chartDataType"
+                                            data-action="click->mempool#setSizeDataType" class="nav-link active"
+                                            href="javascript:void(0);" data-option="table">Size</a>
                                     </li>
                                     <li class="nav-item">
-                                        <a
-                                        data-target="mempool.chartDataType"
-                                        data-action="click->mempool#setFeesDataType"
-                                        class="nav-link"
-                                        href="javascript:void(0);"
-                                        data-option="table"
-                                        >Fees</a>
+                                        <a data-target="mempool.chartDataType"
+                                            data-action="click->mempool#setFeesDataType" class="nav-link"
+                                            href="javascript:void(0);" data-option="table">Fees</a>
                                     </li>
                                     <li class="nav-item">
-                                        <a
-                                        data-target="mempool.chartDataType"
-                                        data-action="click->mempool#setTransactionsDataType"
-                                        class="nav-link"
-                                        href="javascript:void(0);"
-                                        data-option="table"
-                                        >Transactions</a>
+                                        <a data-target="mempool.chartDataType"
+                                            data-action="click->mempool#setTransactionsDataType" class="nav-link"
+                                            href="javascript:void(0);" data-option="table">Transactions</a>
                                     </li>
                                 </ul>
                             </div>
@@ -83,7 +66,8 @@
                         <div data-target="mempool.numPageWrapper" class="control-div p-0 ml-auto">
                             <div class="control-label">Page Size:</div>
 
-                            <select data-target="mempool.selectedNum" data-action="change->mempool#NumberOfRowsChanged" class="form-control" style="width: 70px;">
+                            <select data-target="mempool.selectedNum" data-action="change->mempool#NumberOfRowsChanged"
+                                class="form-control" style="width: 70px;">
                                 <option value="20">20</option>
                                 <option value="30">30</option>
                                 <option value="50">50</option>
@@ -93,18 +77,24 @@
                         </div>
                         <div class="d-flex">
                             <div data-target="mempool.btnWrapper" class="float-md-right">
-                                <button data-target="mempool.previousPageButton" data-action="click->mempool#gotoPreviousPage" data-previous-page="{{ .mempool.previousPage}}"
+                                <button data-target="mempool.previousPageButton"
+                                    data-action="click->mempool#gotoPreviousPage"
+                                    data-previous-page="{{ .mempool.previousPage}}"
                                     class="btn btn-link {{ if lt .mempool.previousPage 1 }}d-none{{ end }}">
                                     &lt; Previous
                                 </button>
 
-                                <span data-target="mempool.pageReport" class="text-muted" style="white-space: nowrap;" data-current-page="{{ .mempool.currentPage }}">
-                                    Page <span data-target="mempool.currentPage" data-current-page="{{ .mempool.currentPage }}">{{ .mempool.currentPage }}</span> of
+                                <span data-target="mempool.pageReport" class="text-muted" style="white-space: nowrap;"
+                                    data-current-page="{{ .mempool.currentPage }}">
+                                    Page <span data-target="mempool.currentPage"
+                                        data-current-page="{{ .mempool.currentPage }}">{{ .mempool.currentPage }}</span>
+                                    of
                                     <span data-target="mempool.totalPageCount">{{ .mempool.totalPages }}</span>
                                 </span>
 
                                 <button data-target="mempool.nextPageButton" data-action="click->mempool#gotoNextPage"
-                                    data-next-page="{{ .mempool.nextPage }}" class="btn btn-link {{ if not .mempool.nextPage }}d-none{{ end }}">
+                                    data-next-page="{{ .mempool.nextPage }}"
+                                    class="btn btn-link {{ if not .mempool.nextPage }}d-none{{ end }}">
                                     Next &gt;
                                 </button>
                             </div>
@@ -112,7 +102,7 @@
                     </div>
                 </div>
 
-                <div >
+                <div>
                     <div data-target="mempool.tableWrapper">
                         <table class="table">
                             <thead>
@@ -145,7 +135,8 @@
                         </template>
                     </div>
                     <div data-target="mempool.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-hide">
-                        <div id="chart" data-target="mempool.chartsView" style="width:100%; height:73vh; margin:0 auto;"></div>
+                        <div id="chart" data-target="mempool.chartsView"
+                            style="width:100%; height:73vh; margin:0 auto;"></div>
                         <div class="d-flex justify-content-center legend-wrapper">
                             <div class="legend d-flex" data-target="mempool.labels"></div>
                         </div>
@@ -156,4 +147,5 @@
     </div>
     {{ template "footer" }}
 </body>
+
 </html>

--- a/web/views/mempool.html
+++ b/web/views/mempool.html
@@ -8,9 +8,6 @@
         <div class="content">
             <div class="container-fluid">
                 <div class="control-wrapper">
-                    <!-- <div class="d-block text-center">
-                        <h4>Mempool</h4>
-                    </div> -->
                     <div class="d-flex flex-row">
                         <div class="chart-control ml-auto mr-3">
                             <ul class="nav nav-pills">
@@ -149,5 +146,4 @@
     </div>
     {{ template "footer" }}
 </body>
-
 </html>

--- a/web/views/mempool.html
+++ b/web/views/mempool.html
@@ -11,24 +11,22 @@
                     <!-- <div class="d-block text-center">
                         <h4>Mempool</h4>
                     </div> -->
-                    
-                    <div class="chart-control-wrapper mr-3 mb-3" data-target="mempool.chartSelector">
-                        <div class="chart-control mx-auto">
+                    <div class="d-flex flex-row">
+                        <div class="chart-control ml-auto mr-3">
                             <ul class="nav nav-pills">
                                 <li class="nav-item">
-                                    <a class="nav-link active" href="javascript:void(0);"
+                                    <a class="nav-link active" href="javascript:void(0);" data-target="mempool.viewOption"
+                                        data-action="click->mempool#setChart" data-option="chart">Chart</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="javascript:void(0);"
                                         data-target="mempool.viewOption" data-action="click->mempool#setTable"
                                         data-option="table">Table</a>
                                 </li>
-                                <li class="nav-item">
-                                    <a class="nav-link" href="javascript:void(0);" data-target="mempool.viewOption"
-                                        data-action="click->mempool#setChart" data-option="chart">Chart</a>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <div class="d-flex flex-row">
-                        <div class="d-flex mx-auto">
+
+                        <div class="d-flex mr-auto">
 
                             <div data-target="mempool.chartOptions" class="control-div p-0 d-hide">
                                 <div class="control-label ">Mempool Charts:</div>
@@ -107,7 +105,7 @@
                 </div>
 
                 <div>
-                    <div data-target="mempool.tableWrapper">
+                    <div class="d-hide" data-target="mempool.tableWrapper">
                         <table class="table mx-auto">
                             <thead>
                                 <tr>
@@ -138,7 +136,7 @@
                             </tr>
                         </template>
                     </div>
-                    <div data-target="mempool.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-hide">
+                    <div data-target="mempool.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5">
                         <div id="chart" data-target="mempool.chartsView"
                             style="width:100%; height:73vh; margin:0 auto;"></div>
                         <div class="d-flex justify-content-center legend-wrapper">

--- a/web/views/mempool.html
+++ b/web/views/mempool.html
@@ -73,7 +73,7 @@
                                 </select>
                             </div>
                             <div class="d-flex">
-                                <div data-target="mempool.btnWrapper" class="float-md-right">
+                                <div data-target="mempool.btnWrapper" class=" control-div float-md-right">
                                     <button data-target="mempool.previousPageButton"
                                         data-action="click->mempool#gotoPreviousPage"
                                         data-previous-page="{{ .mempool.previousPage}}"

--- a/web/views/pow.html
+++ b/web/views/pow.html
@@ -1,123 +1,119 @@
 <!DOCTYPE html>
 <html lang="en">
 {{ template "html-head" }}
+
 <body>
     <div class="body" data-controller="pow">
         {{ template "header" }}
         <div class="content">
-            <div class="container">
+            <div class="container-fluid">
                 <div class="control-wrapper">
-                   <div class="chart-control-wrapper mb-2" data-target="pow.chartSelector">
-                       <div class="chart-control">
-                        <ul
-                        class="nav nav-pills"
-                        >
-                        <li class="nav-item">
-                            <a
-                            class="nav-link active"
-                            href="javascript:void(0);"
-                            data-target="pow.viewOption"
-                            data-action="click->pow#setTable"
-                            data-option="table"
-                            >Table</a>
-                        </li>
-                        <li class="nav-item">
-                            <a
-                            class="nav-link"
-                            href="javascript:void(0);"
-                            data-target="pow.viewOption"
-                            data-action="click->pow#setChart"
-                            data-option="chart"
-                            >Chart</a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-            <div class="d-flex flex-row">
-                <div class="control-div p-0">
-                    <div class="control-label">Pool:</div>
-                    <select data-target="pow.selectedFilter" data-action="change->pow#selectedFilterChanged"
-                        class="form-control" style="width: 110px;">
+                    <div class="chart-control-wrapper mb-2" data-target="pow.chartSelector">
+                        <div class="chart-control">
+                            <ul class="nav nav-pills">
+                                <li class="nav-item">
+                                    <a class="nav-link active" href="javascript:void(0);" data-target="pow.viewOption"
+                                        data-action="click->pow#setTable" data-option="table">Table</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="javascript:void(0);" data-target="pow.viewOption"
+                                        data-action="click->pow#setChart" data-option="chart">Chart</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="d-flex flex-row">
+                        <div class="control-div p-0">
+                            <div class="control-label">Pool:</div>
+                            <select data-target="pow.selectedFilter" data-action="change->pow#selectedFilterChanged"
+                                class="form-control" style="width: 110px;">
 
-                        <option value="All" selected>All</option>
-                        {{ range $index, $filter := .powSource}}
-                        <option value="{{$filter.Source}}">{{$filter.Source}}</option>
-                        {{ end }}
-                    </select>
-                </div>
-                <div data-target="pow.numPageWrapper" class="control-div p-0 ml-auto">
-                    <div class=" mb-2 float-md-right">
-                        <div class="control-label">Page Size:</div>
-                        <select data-target="pow.selectedNum" data-action="change->pow#numberOfRowsChanged" class="form-control mr-5" style="width: 70px;">
-                            <option value="20" selected>20</option>
-                            <option value="30">30</option>
-                            <option value="50">50</option>
-                            <option value="100">100</option>
-                            <option value="150">150</option>
-                        </select>
-                    </div>
-                    </div>
+                                <option value="All" selected>All</option>
+                                {{ range $index, $filter := .powSource}}
+                                <option value="{{$filter.Source}}">{{$filter.Source}}</option>
+                                {{ end }}
+                            </select>
+                        </div>
+                        <div data-target="pow.numPageWrapper" class="control-div p-0 ml-auto">
+                            <div class=" mb-2 float-md-right">
+                                <div class="control-label">Page Size:</div>
+                                <select data-target="pow.selectedNum" data-action="change->pow#numberOfRowsChanged"
+                                    class="form-control mr-5" style="width: 70px;">
+                                    <option value="20" selected>20</option>
+                                    <option value="30">30</option>
+                                    <option value="50">50</option>
+                                    <option value="100">100</option>
+                                    <option value="150">150</option>
+                                </select>
+                            </div>
+                        </div>
                         <div data-target="pow.pageSizeWrapper" class="d-flex">
-                            <a href="javascript:void(0)" data-target="pow.previousPageButton" data-action="click->pow#loadPreviousPage" data-next-page="{{ .previousPage }}" class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
+                            <a href="javascript:void(0)" data-target="pow.previousPageButton"
+                                data-action="click->pow#loadPreviousPage" data-next-page="{{ .previousPage }}"
+                                class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
 
-                            <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="pow.currentPage" class="text-muted"> {{ .currentPage }}</span> of <span data-target="pow.totalPageCount" class="text-muted">{{ .totalPages }}</span>
-                            </p>    
-                            <a href="javascript:void(0)" data-target="pow.nextPageButton" data-action="click->pow#loadNextPage" data-total-page="{{ .totalPages }}" data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}"> Next&gt;</a>
+                            <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="pow.currentPage"
+                                    class="text-muted"> {{ .currentPage }}</span> of <span
+                                    data-target="pow.totalPageCount" class="text-muted">{{ .totalPages }}</span>
+                            </p>
+                            <a href="javascript:void(0)" data-target="pow.nextPageButton"
+                                data-action="click->pow#loadNextPage" data-total-page="{{ .totalPages }}"
+                                data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}">
+                                Next&gt;</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="" data-target="pow.powTableWrapper">
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 110px;">Pool</th>
+                                        <th style="text-align: right; width: 150px;">Pool Hashrate (Th/s)</th>
+                                        <th style="text-align: right;width: 150px;">Workers</th>
+                                        <th style="width: 50px;"></th>
+                                        <th>Time (UTC)</th>
+                                    </tr>
+                                </thead>
+                                <tbody data-target="pow.powTable">
+                                    {{range $index, $powdata := .powData}}
+                                    <tr>
+                                        <td>{{$powdata.Source}}</td>
+                                        <td style="text-align: right;">{{$powdata.PoolHashrateTh}}</td>
+                                        <td style="text-align: right;">{{$powdata.Workers}}</td>
+                                        <td></td>
+                                        <td>{{$powdata.Time}}</td>
+                                    </tr>
+                                    {{end}}
+                                </tbody>
+                            </table>
+
+                            <template data-target="pow.powRowTemplate">
+                                <tr>
+                                    <td></td>
+                                    <td style="text-align: right;"></td>
+                                    <td style="text-align: right;"></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
+                            </template>
+                        </div>
+                    </div>
+                </div>
+
+                <div data-target="pow.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-hide">
+                    <div id="chart" data-target="pow.chartsView" style="width:100%; height:73vh; margin:0 auto;">
+                    </div>
+                    <div class="d-flex justify-content-center legend-wrapper">
+                        <div class="legend d-flex" data-target="pow.labels"></div>
+                    </div>
                 </div>
             </div>
-        </div>
-
-        <div class="row">
-            <div class="col-md-10 offset-1">
-                <div class="" data-target="pow.powTableWrapper">
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th style="width: 110px;">Pool</th>
-                                <th style="text-align: right; width: 150px;">Pool Hashrate (Th/s)</th>
-                                <th style="text-align: right;width: 150px;">Workers</th>
-                                <th style="width: 50px;"></th>
-                                <th>Time (UTC)</th>
-                            </tr>
-                        </thead>
-                        <tbody data-target="pow.powTable">
-                            {{range $index, $powdata := .powData}}
-                            <tr>
-                                <td>{{$powdata.Source}}</td>
-                                <td style="text-align: right;">{{$powdata.PoolHashrateTh}}</td>
-                                <td style="text-align: right;">{{$powdata.Workers}}</td>
-                                <td></td>
-                                <td>{{$powdata.Time}}</td>
-                            </tr>
-                            {{end}}
-                        </tbody>
-                    </table>
-
-                    <template data-target="pow.powRowTemplate">
-                        <tr>
-                            <td></td>
-                            <td style="text-align: right;"></td>
-                            <td style="text-align: right;"></td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                    </template>
-                </div>
-            </div>
-        </div>
-
-        <div data-target="pow.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-hide">
-            <div id="chart"
-            data-target="pow.chartsView"
-            style="width:100%; height:73vh; margin:0 auto;">
-        </div>
-        <div class="d-flex justify-content-center legend-wrapper">
-            <div class="legend d-flex" data-target="pow.labels"></div>
         </div>
     </div>
-</div>
-</div>
-</div>
-{{ template "footer" }}
+    {{ template "footer" }}
 </body>
+
 </html>

--- a/web/views/pow.html
+++ b/web/views/pow.html
@@ -9,7 +9,7 @@
             <div class="container-fluid">
                 <div class="control-wrapper">
                     <div class="chart-control-wrapper mb-2" data-target="pow.chartSelector">
-                        <div class="chart-control">
+                        <div class="chart-control mx-auto">
                             <ul class="nav nav-pills">
                                 <li class="nav-item">
                                     <a class="nav-link active" href="javascript:void(0);" data-target="pow.viewOption"
@@ -23,43 +23,45 @@
                         </div>
                     </div>
                     <div class="d-flex flex-row">
-                        <div class="control-div p-0">
-                            <div class="control-label">Pool:</div>
-                            <select data-target="pow.selectedFilter" data-action="change->pow#selectedFilterChanged"
-                                class="form-control" style="width: 110px;">
+                        <div class="mx-auto d-flex">
+                            <div class="control-div p-0">
+                                <div class="control-label">Pool:</div>
+                                <select data-target="pow.selectedFilter" data-action="change->pow#selectedFilterChanged"
+                                    class="form-control" style="width: 110px;">
 
-                                <option value="All" selected>All</option>
-                                {{ range $index, $filter := .powSource}}
-                                <option value="{{$filter.Source}}">{{$filter.Source}}</option>
-                                {{ end }}
-                            </select>
-                        </div>
-                        <div data-target="pow.numPageWrapper" class="control-div p-0 ml-auto">
-                            <div class=" mb-2 float-md-right">
-                                <div class="control-label">Page Size:</div>
-                                <select data-target="pow.selectedNum" data-action="change->pow#numberOfRowsChanged"
-                                    class="form-control mr-5" style="width: 70px;">
-                                    <option value="20" selected>20</option>
-                                    <option value="30">30</option>
-                                    <option value="50">50</option>
-                                    <option value="100">100</option>
-                                    <option value="150">150</option>
+                                    <option value="All" selected>All</option>
+                                    {{ range $index, $filter := .powSource}}
+                                    <option value="{{$filter.Source}}">{{$filter.Source}}</option>
+                                    {{ end }}
                                 </select>
                             </div>
-                        </div>
-                        <div data-target="pow.pageSizeWrapper" class="d-flex">
-                            <a href="javascript:void(0)" data-target="pow.previousPageButton"
-                                data-action="click->pow#loadPreviousPage" data-next-page="{{ .previousPage }}"
-                                class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
+                            <div data-target="pow.numPageWrapper" class="control-div p-0 ml-5">
+                                <div class=" mb-2 float-md-right">
+                                    <div class="control-label">Page Size:</div>
+                                    <select data-target="pow.selectedNum" data-action="change->pow#numberOfRowsChanged"
+                                        class="form-control mr-5" style="width: 70px;">
+                                        <option value="20" selected>20</option>
+                                        <option value="30">30</option>
+                                        <option value="50">50</option>
+                                        <option value="100">100</option>
+                                        <option value="150">150</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div data-target="pow.pageSizeWrapper" class="d-inline pt-1">
+                                <a href="javascript:void(0)" data-target="pow.previousPageButton"
+                                    data-action="click->pow#loadPreviousPage" data-next-page="{{ .previousPage }}"
+                                    class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
 
-                            <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="pow.currentPage"
-                                    class="text-muted"> {{ .currentPage }}</span> of <span
-                                    data-target="pow.totalPageCount" class="text-muted">{{ .totalPages }}</span>
-                            </p>
-                            <a href="javascript:void(0)" data-target="pow.nextPageButton"
-                                data-action="click->pow#loadNextPage" data-total-page="{{ .totalPages }}"
-                                data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}">
-                                Next&gt;</a>
+                                <p class="text-muted d-inline" style="white-space: nowrap;"> Page <span data-target="pow.currentPage"
+                                        class="text-muted"> {{ .currentPage }}</span> of <span
+                                        data-target="pow.totalPageCount" class="text-muted">{{ .totalPages }}</span>
+                                </p>
+                                <a href="javascript:void(0)" data-target="pow.nextPageButton"
+                                    data-action="click->pow#loadNextPage" data-total-page="{{ .totalPages }}"
+                                    data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}">
+                                    Next&gt;</a>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -67,7 +69,7 @@
                 <div class="row">
                     <div class="col-md-12">
                         <div class="" data-target="pow.powTableWrapper">
-                            <table class="table">
+                            <table class="table mx-auto">
                                 <thead>
                                     <tr>
                                         <th style="width: 110px;">Pool</th>

--- a/web/views/pow.html
+++ b/web/views/pow.html
@@ -65,9 +65,9 @@
                     </div>
                 </div>
 
-                <div class="row d-hide">
+                <div class="row d-hide" data-target="pow.powTableWrapper">
                     <div class="col-md-12">
-                        <div class="" data-target="pow.powTableWrapper">
+                        <div class="">
                             <table class="table mx-auto">
                                 <thead>
                                     <tr>

--- a/web/views/pow.html
+++ b/web/views/pow.html
@@ -47,7 +47,7 @@
                                     </select>
                                 </div>
                             </div>
-                            <div data-target="pow.pageSizeWrapper" class="d-inline pt-1">
+                            <div data-target="pow.pageSizeWrapper" class="d-inline pt-1 control-div">
                                 <a href="javascript:void(0)" data-target="pow.previousPageButton"
                                     data-action="click->pow#loadPreviousPage" data-next-page="{{ .previousPage }}"
                                     class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>

--- a/web/views/pow.html
+++ b/web/views/pow.html
@@ -116,5 +116,4 @@
     </div>
     {{ template "footer" }}
 </body>
-
 </html>

--- a/web/views/pow.html
+++ b/web/views/pow.html
@@ -8,22 +8,21 @@
         <div class="content">
             <div class="container-fluid">
                 <div class="control-wrapper">
-                    <div class="chart-control-wrapper mb-2" data-target="pow.chartSelector">
-                        <div class="chart-control mx-auto">
-                            <ul class="nav nav-pills">
-                                <li class="nav-item">
-                                    <a class="nav-link active" href="javascript:void(0);" data-target="pow.viewOption"
-                                        data-action="click->pow#setTable" data-option="table">Table</a>
-                                </li>
+                    <div class="d-flex flex-row">
+                        <div class="chart-control ml-auto mr-5">
+                            <ul class="nav nav-pills"> 
                                 <li class="nav-item">
                                     <a class="nav-link" href="javascript:void(0);" data-target="pow.viewOption"
                                         data-action="click->pow#setChart" data-option="chart">Chart</a>
                                 </li>
+                                <li class="nav-item">
+                                    <a class="nav-link active" href="javascript:void(0);" data-target="pow.viewOption"
+                                        data-action="click->pow#setTable" data-option="table">Table</a>
+                                </li>
+                               
                             </ul>
                         </div>
-                    </div>
-                    <div class="d-flex flex-row">
-                        <div class="mx-auto d-flex">
+                        <div class="d-flex mr-auto">
                             <div class="control-div p-0">
                                 <div class="control-label">Pool:</div>
                                 <select data-target="pow.selectedFilter" data-action="change->pow#selectedFilterChanged"
@@ -66,7 +65,7 @@
                     </div>
                 </div>
 
-                <div class="row">
+                <div class="row d-hide">
                     <div class="col-md-12">
                         <div class="" data-target="pow.powTableWrapper">
                             <table class="table mx-auto">
@@ -105,7 +104,7 @@
                     </div>
                 </div>
 
-                <div data-target="pow.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-hide">
+                <div data-target="pow.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5">
                     <div id="chart" data-target="pow.chartsView" style="width:100%; height:73vh; margin:0 auto;">
                     </div>
                     <div class="d-flex justify-content-center legend-wrapper">

--- a/web/views/pow.html
+++ b/web/views/pow.html
@@ -9,7 +9,7 @@
             <div class="container-fluid">
                 <div class="control-wrapper">
                     <div class="d-flex flex-row">
-                        <div class="chart-control ml-auto mr-5">
+                        <div class="chart-control ml-auto mr-3">
                             <ul class="nav nav-pills"> 
                                 <li class="nav-item">
                                     <a class="nav-link" href="javascript:void(0);" data-target="pow.viewOption"
@@ -34,11 +34,11 @@
                                     {{ end }}
                                 </select>
                             </div>
-                            <div data-target="pow.numPageWrapper" class="control-div p-0 ml-5">
+                            <div data-target="pow.numPageWrapper" class="control-div p-0 ml-1">
                                 <div class=" mb-2 float-md-right">
                                     <div class="control-label">Page Size:</div>
                                     <select data-target="pow.selectedNum" data-action="change->pow#numberOfRowsChanged"
-                                        class="form-control mr-5" style="width: 70px;">
+                                        class="form-control mr-1" style="width: 70px;">
                                         <option value="20" selected>20</option>
                                         <option value="30">30</option>
                                         <option value="50">50</option>

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -134,7 +134,7 @@
                             </tbody>
                             <tbody>
                                 <tr>
-                                    <td colspan="7" height="30" style="border: none !important;"></td>
+                                    <td colspan="7" height="15" style="border: none !important;"></td>
                                 </tr>
                             </tbody>
                         {{end}}

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -19,18 +19,18 @@
                                                     class="nav-link active"
                                                     href="javascript:void(0);"
                                                     data-target="propagation.viewOption"
-                                                    data-action="click->propagation#setTable"
-                                                    data-option="table"
-                                            >Table</a>
+                                                    data-action="click->propagation#setChart"
+                                                    data-option="chart"
+                                            >Chart</a>
                                         </li>
                                         <li class="nav-item">
                                             <a
                                                     class="nav-link"
                                                     href="javascript:void(0);"
                                                     data-target="propagation.viewOption"
-                                                    data-action="click->propagation#setChart"
-                                                    data-option="chart"
-                                            >Chart</a>
+                                                    data-action="click->propagation#setTable"
+                                                    data-option="table"
+                                            >Table</a>
                                         </li>
                                     </ul>
                                 </div>
@@ -88,49 +88,54 @@
                     </div>
                 </div>
 
-                <div data-target="propagation.tablesWrapper">
+                <div data-target="propagation.tablesWrapper d-hide">
                     {{/*combine view*/}}
                     <table class="table collapsible mx-auto" data-target="propagation.table">
                         {{range $index, $block := .propagation.records}}
                             <tbody data-target="propagation.blocksTbody" data-block-hash="{{$block.BlockHash}}">
-                            <tr>
-                                <td colspan="100">
-                                    <span class="d-inline-block"><b>Height</b>: {{$block.BlockHeight}}</span> &#8195;
-                                    <span class="d-inline-block"><b>Timestamp</b>: {{$block.BlockInternalTime}}</span>
-                                    &#8195;
-                                    <span class="d-inline-block"><b>Received</b>: {{$block.BlockReceiveTime}}</span>
-                                    &#8195;
-                                    <span class="d-inline-block"><b>Hash</b>: <a target="_blank"
-                                            href="https://explorer.dcrdata.org/block/{{$block.BlockHeight}}">{{$block.BlockHash}}</a></span>
-                                </td>
-                            </tr>
+                                <tr>
+                                    <td colspan="100">
+                                        <span class="d-inline-block"><b>Height</b>: {{$block.BlockHeight}}</span> &#8195;
+                                        <span class="d-inline-block"><b>Timestamp</b>: {{$block.BlockInternalTime}}</span>
+                                        &#8195;
+                                        <span class="d-inline-block"><b>Received</b>: {{$block.BlockReceiveTime}}</span>
+                                        &#8195;
+                                        <span class="d-inline-block"><b>Hash</b>: <a target="_blank"
+                                                href="https://explorer.dcrdata.org/block/{{$block.BlockHeight}}">{{$block.BlockHash}}</a></span>
+                                    </td>
+                                </tr>
                             </tbody>
                             <tbody data-target="propagation.votesTbody" data-block-hash="{{$block.BlockHash}}">
-                            <tr style="white-space: nowrap;">
-                                <td style="width: 120px;">Voting On</td>
-                                <td style="width: 120px;">Block Hash</td>
-                                <td style="width: 120px;">Validator ID</td>
-                                <td style="width: 120px;">Validity</td>
-                                <td style="width: 120px;">Block Receive</td>
-                                <td style="width: 120px;">Block Receive Time Diff</td>
-                                <td style="width: 120px;">Hash</td>
-                            </tr>
-                            {{range $index, $vote := $block.Votes}}
-                                <tr>
-                                    <td><a target="_blank"
-                                           href="https://explorer.dcrdata.org/block/{{$vote.VotingOn}}">{{$vote.VotingOn}}</a>
-                                    </td>
-                                    <td><a target="_blank"
-                                           href="https://explorer.dcrdata.org/block/{{$vote.BlockHash}}">...{{$vote.ShortBlockHash}}</a>
-                                    </td>
-                                    <td>{{$vote.ValidatorId}}</td>
-                                    <td>{{$vote.Validity}}</td>
-                                    <td>{{$vote.ReceiveTime}}</td>
-                                    <td>{{$vote.BlockReceiveTimeDiff}}s</td>
-                                    <td><a target="_blank"
-                                           href="https://explorer.dcrdata.org/tx/{{$vote.Hash}}">{{$vote.Hash}}</a></td>
+                                <tr style="white-space: nowrap;">
+                                    <td style="width: 120px;">Voting On</td>
+                                    <td style="width: 120px;">Block Hash</td>
+                                    <td style="width: 120px;">Validator ID</td>
+                                    <td style="width: 120px;">Validity</td>
+                                    <td style="width: 120px;">Block Receive</td>
+                                    <td style="width: 120px;">Block Receive Time Diff</td>
+                                    <td style="width: 120px;">Hash</td>
                                 </tr>
-                            {{end}}
+                                {{range $index, $vote := $block.Votes}}
+                                    <tr>
+                                        <td><a target="_blank"
+                                            href="https://explorer.dcrdata.org/block/{{$vote.VotingOn}}">{{$vote.VotingOn}}</a>
+                                        </td>
+                                        <td><a target="_blank"
+                                            href="https://explorer.dcrdata.org/block/{{$vote.BlockHash}}">...{{$vote.ShortBlockHash}}</a>
+                                        </td>
+                                        <td>{{$vote.ValidatorId}}</td>
+                                        <td>{{$vote.Validity}}</td>
+                                        <td>{{$vote.ReceiveTime}}</td>
+                                        <td>{{$vote.BlockReceiveTimeDiff}}s</td>
+                                        <td><a target="_blank"
+                                            href="https://explorer.dcrdata.org/tx/{{$vote.Hash}}">{{$vote.Hash}}</a></td>
+                                    </tr>
+                                {{end}}
+                            </tbody>
+                            <tbody>
+                                <tr>
+                                    <td colspan="7" height="50" style="border: none !important;"></td>
+                                </tr>
                             </tbody>
                         {{end}}
                     </table>
@@ -192,7 +197,7 @@
                     </template>
                 </div>
 
-                <div data-target="propagation.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-hide" style="width:100%;">
+                <div data-target="propagation.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5" style="width:100%;">
                     <div id="chart" data-target="propagation.chartsView" style="width:100%; height:73vh; margin:0 auto;"></div>
                     <div class="d-flex justify-content-center legend-wrapper">
                         <div class="legend d-flex" data-target="propagation.labels"></div>

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -20,7 +20,7 @@
                                 </select>
                             </div>
 
-                            <div data-target="propagation.numPageWrapper" class="control-div ml-5 p-0">
+                            <div data-target="propagation.numPageWrapper" class="control-div ml-2 p-0">
                                 <div class="control-label">Page Size:</div>
                                 <select data-target="propagation.selectedNum"
                                     data-action="change->propagation#numberOfRowsChanged" class="form-control"
@@ -125,7 +125,7 @@
                     </table>
 
                     {{/*blocks only*/}}
-                    <table class="table d-none" data-target="propagation.blocksTable">
+                    <table class="table d-none mx-auto" data-target="propagation.blocksTable">
                         <thead>
                         <tr style="white-space: nowrap;">
                             <th>Height</th>
@@ -150,7 +150,7 @@
                     </template>
 
                     {{/*votes only*/}}
-                    <table data-target="propagation.votesTable" class="table d-none">
+                    <table data-target="propagation.votesTable" class="table d-none mx-auto">
                         <thead>
                         <tr style="white-space: nowrap;">
                             <th>Voting On</th>

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -34,7 +34,7 @@
                             </div>
 
                             <div class="d-flex">
-                                <div class="float-md-right">
+                                <div class="float-md-right control-div">
                                     <button data-target="propagation.previousPageButton"
                                         data-action="click->propagation#gotoPreviousPage"
                                         data-previous-page="{{ .propagation.previousPage}}"

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -10,11 +10,36 @@
                 <div class="control-div p-0">
                     <div class="d-flex flex-row mb-3 mt-1">
                         <div class="mx-auto d-flex">
+                            
+                            <div class="chart-control-wrapper mr-3" data-target="propagation.chartSelector">
+                                <div class="chart-control ">
+                                    <ul class="nav nav-pills">
+                                        <li class="nav-item">
+                                            <a
+                                                    class="nav-link active"
+                                                    href="javascript:void(0);"
+                                                    data-target="propagation.viewOption"
+                                                    data-action="click->propagation#setTable"
+                                                    data-option="table"
+                                            >Table</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a
+                                                    class="nav-link"
+                                                    href="javascript:void(0);"
+                                                    data-target="propagation.viewOption"
+                                                    data-action="click->propagation#setChart"
+                                                    data-option="chart"
+                                            >Chart</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
                             <div class="chart-control control-div p-0">
                                 <select data-target="propagation.selectedRecordSet"
                                     data-action="change->propagation#selectedRecordSetChanged" class="form-control "
                                     style="width: 150px;">
-                                    <option value="both">Both</option>
+                                    <option data-target="propagation.bothRecordSetOption" value="both">Both</option>
                                     <option value="blocks">Blocks</option>
                                     <option value="votes">Votes</option>
                                 </select>
@@ -33,7 +58,7 @@
                                 </select>
                             </div>
 
-                            <div class="d-flex">
+                            <div class="d-flex" data-target="propagation.paginationButtonsWrapper">
                                 <div class="float-md-right control-div">
                                     <button data-target="propagation.previousPageButton"
                                         data-action="click->propagation#gotoPreviousPage"
@@ -107,20 +132,6 @@
                                 </tr>
                             {{end}}
                             </tbody>
-                            <tr>
-                                <td><a target="_blank"
-                                        href="https://explorer.dcrdata.org/block/{{$vote.VotingOn}}">{{$vote.VotingOn}}</a>
-                                </td>
-                                <td><a target="_blank"
-                                        href="https://explorer.dcrdata.org/block/{{$vote.BlockHash}}">...{{$vote.ShortBlockHash}}</a>
-                                </td>
-                                <td>{{$vote.ValidatorId}}</td>
-                                <td>{{$vote.Validity}}</td>
-                                <td>{{$vote.ReceiveTime}}</td>
-                                <td>{{$vote.BlockReceiveTimeDiff}}s</td>
-                                <td><a target="_blank"
-                                        href="https://explorer.dcrdata.org/tx/{{$vote.Hash}}">{{$vote.Hash}}</a></td>
-                            </tr>
                         {{end}}
                     </table>
 

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -1,17 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 {{ template "html-head" }}
-<body data-controller="receive">
-<div class="body" data-controller="propagation">
-    {{ template "header" }}
-    <div class="content">
-        <div class="container">
 
-                <div class="control-wrapper">
+<body data-controller="receive">
+    <div class="body" data-controller="propagation">
+        {{ template "header" }}
+        <div class="content">
+            <div class="container-fluid">
+                <div class="control-div p-0">
                     <div class="d-block">
                         <h4>Propagation</h4>
                     </div>
-
                     <div class="d-flex flex-row">
                         <div class="chart-control-wrapper mr-3" data-target="propagation.chartSelector">
                             <div class="chart-control ">
@@ -51,8 +50,8 @@
                         <div data-target="propagation.numPageWrapper" class="control-div ml-auto p-0">
                             <div class="control-label">Page Size:</div>
                             <select data-target="propagation.selectedNum"
-                                    data-action="change->propagation#numberOfRowsChanged" class="form-control"
-                                    style="width: 70px;">
+                                data-action="change->propagation#numberOfRowsChanged" class="form-control"
+                                style="width: 70px;">
                                 <option value="20">20</option>
                                 <option value="30">30</option>
                                 <option value="50">50</option>
@@ -61,26 +60,28 @@
                             </select>
                         </div>
 
-                        <div class="d-flex" data-target="propagation.paginationButtonsWrapper">
+                        <div class="d-flex">
                             <div class="float-md-right">
                                 <button data-target="propagation.previousPageButton"
-                                        data-action="click->propagation#gotoPreviousPage"
-                                        data-previous-page="{{ .propagation.previousPage}}"
-                                        class="btn btn-link {{ if lt .propagation.previousPage 1 }}d-none{{ end }}">
+                                    data-action="click->propagation#gotoPreviousPage"
+                                    data-previous-page="{{ .propagation.previousPage}}"
+                                    class="btn btn-link {{ if lt .propagation.previousPage 1 }}d-none{{ end }}">
                                     &lt; Previous
                                 </button>
 
-                                <span data-target="propagation.pageReport" style="white-space: nowrap;" class="text-muted"
-                                      data-current-page="{{ .propagation.currentPage }}" style="padding-top: 6.5px;">
-                                        Page <span data-target="propagation.currentPage"
-                                                   data-current-page="{{ .propagation.currentPage }}">{{ .propagation.currentPage }}</span> of
-                                        <span data-target="propagation.totalPageCount">{{ .propagation.totalPages }}</span>
-                                    </span>
+                                <span data-target="propagation.pageReport" style="white-space: nowrap;"
+                                    class="text-muted" data-current-page="{{ .propagation.currentPage }}"
+                                    style="padding-top: 6.5px;">
+                                    Page <span data-target="propagation.currentPage"
+                                        data-current-page="{{ .propagation.currentPage }}">{{ .propagation.currentPage }}</span>
+                                    of
+                                    <span data-target="propagation.totalPageCount">{{ .propagation.totalPages }}</span>
+                                </span>
 
                                 <button data-target="propagation.nextPageButton"
-                                        data-action="click->propagation#gotoNextPage"
-                                        data-next-page="{{ .propagation.nextPage }}"
-                                        class="btn btn-link {{ if not .propagation.nextPage }}d-none{{ end }}">
+                                    data-action="click->propagation#gotoNextPage"
+                                    data-next-page="{{ .propagation.nextPage }}"
+                                    class="btn btn-link {{ if not .propagation.nextPage }}d-none{{ end }}"
                                     Next &gt;
                                 </button>
                             </div>
@@ -98,9 +99,10 @@
                                     <span class="d-inline-block"><b>Height</b>: {{$block.BlockHeight}}</span> &#8195;
                                     <span class="d-inline-block"><b>Timestamp</b>: {{$block.BlockInternalTime}}</span>
                                     &#8195;
-                                    <span class="d-inline-block"><b>Received</b>: {{$block.BlockReceiveTime}}</span> &#8195;
+                                    <span class="d-inline-block"><b>Received</b>: {{$block.BlockReceiveTime}}</span>
+                                    &#8195;
                                     <span class="d-inline-block"><b>Hash</b>: <a target="_blank"
-                                                                                 href="https://explorer.dcrdata.org/block/{{$block.BlockHeight}}">{{$block.BlockHash}}</a></span>
+                                            href="https://explorer.dcrdata.org/block/{{$block.BlockHeight}}">{{$block.BlockHash}}</a></span>
                                 </td>
                             </tr>
                             </tbody>
@@ -133,6 +135,13 @@
                             </tbody>
                             <tr>
                                 <td colspan="7" height="50" style="border: none !important;"></td>
+                                <td>{{$vote.VotingOn}}</td>
+                                <td>{{$vote.ValidatorId}}</td>
+                                <td>{{$vote.Validity}}</td>
+                                <td>{{$vote.ReceiveTime}}</td>
+                                <td>{{$vote.BlockReceiveTimeDiff}}s</td>
+                                <td><a target="_blank"
+                                        href="https://explorer.dcrdata.org/tx/{{$vote.Hash}}">{{$vote.Hash}}</a></td>
                             </tr>
                         {{end}}
                     </table>
@@ -200,10 +209,9 @@
                         <div class="legend d-flex" data-target="propagation.labels"></div>
                     </div>
                 </div>
+            </div>
         </div>
     </div>
-</div>
-</div>
-{{ template "footer" }}
+    {{ template "footer" }}
 </body>
 </html>

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -8,82 +8,56 @@
         <div class="content">
             <div class="container-fluid">
                 <div class="control-div p-0">
-                    <div class="d-block">
-                        <h4>Propagation</h4>
-                    </div>
-                    <div class="d-flex flex-row">
-                        <div class="chart-control-wrapper mr-3" data-target="propagation.chartSelector">
-                            <div class="chart-control ">
-                                <ul class="nav nav-pills">
-                                    <li class="nav-item">
-                                        <a
-                                                class="nav-link active"
-                                                href="javascript:void(0);"
-                                                data-target="propagation.viewOption"
-                                                data-action="click->propagation#setTable"
-                                                data-option="table"
-                                        >Table</a>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a
-                                                class="nav-link"
-                                                href="javascript:void(0);"
-                                                data-target="propagation.viewOption"
-                                                data-action="click->propagation#setChart"
-                                                data-option="chart"
-                                        >Chart</a>
-                                    </li>
-                                </ul>
+                    <div class="d-flex flex-row mb-3 mt-1">
+                        <div class="mx-auto d-flex">
+                            <div class="chart-control control-div p-0">
+                                <select data-target="propagation.selectedRecordSet"
+                                    data-action="change->propagation#selectedRecordSetChanged" class="form-control "
+                                    style="width: 150px;">
+                                    <option value="both">Both</option>
+                                    <option value="blocks">Blocks</option>
+                                    <option value="votes">Votes</option>
+                                </select>
                             </div>
-                        </div>
 
-                        <div class="chart-control control-div p-0">
-                            <select data-target="propagation.selectedRecordSet"
-                                    data-action="change->propagation#selectedRecordSetChanged"
-                                    class="form-control " style="width: 150px;">
-                                <option data-target="propagation.bothRecordSetOption" value="both">Both</option>
-                                <option value="blocks">Blocks</option>
-                                <option value="votes">Votes</option>
-                            </select>
-                        </div>
+                            <div data-target="propagation.numPageWrapper" class="control-div ml-5 p-0">
+                                <div class="control-label">Page Size:</div>
+                                <select data-target="propagation.selectedNum"
+                                    data-action="change->propagation#numberOfRowsChanged" class="form-control"
+                                    style="width: 70px;">
+                                    <option value="20">20</option>
+                                    <option value="30">30</option>
+                                    <option value="50">50</option>
+                                    <option value="100">100</option>
+                                    <option value="150">150</option>
+                                </select>
+                            </div>
 
-                        <div data-target="propagation.numPageWrapper" class="control-div ml-auto p-0">
-                            <div class="control-label">Page Size:</div>
-                            <select data-target="propagation.selectedNum"
-                                data-action="change->propagation#numberOfRowsChanged" class="form-control"
-                                style="width: 70px;">
-                                <option value="20">20</option>
-                                <option value="30">30</option>
-                                <option value="50">50</option>
-                                <option value="100">100</option>
-                                <option value="150">150</option>
-                            </select>
-                        </div>
+                            <div class="d-flex">
+                                <div class="float-md-right">
+                                    <button data-target="propagation.previousPageButton"
+                                        data-action="click->propagation#gotoPreviousPage"
+                                        data-previous-page="{{ .propagation.previousPage}}"
+                                        class="btn btn-link {{ if lt .propagation.previousPage 1 }}d-none{{ end }}">
+                                        &lt; Previous
+                                    </button>
 
-                        <div class="d-flex">
-                            <div class="float-md-right">
-                                <button data-target="propagation.previousPageButton"
-                                    data-action="click->propagation#gotoPreviousPage"
-                                    data-previous-page="{{ .propagation.previousPage}}"
-                                    class="btn btn-link {{ if lt .propagation.previousPage 1 }}d-none{{ end }}">
-                                    &lt; Previous
-                                </button>
+                                    <span data-target="propagation.pageReport" style="white-space: nowrap;"
+                                        class="text-muted" data-current-page="{{ .propagation.currentPage }}"
+                                        style="padding-top: 6.5px;">
+                                        Page <span data-target="propagation.currentPage"
+                                            data-current-page="{{ .propagation.currentPage }}">{{ .propagation.currentPage }}</span>
+                                        of
+                                        <span data-target="propagation.totalPageCount">{{ .propagation.totalPages }}</span>
+                                    </span>
 
-                                <span data-target="propagation.pageReport" style="white-space: nowrap;"
-                                    class="text-muted" data-current-page="{{ .propagation.currentPage }}"
-                                    style="padding-top: 6.5px;">
-                                    Page <span data-target="propagation.currentPage"
-                                        data-current-page="{{ .propagation.currentPage }}">{{ .propagation.currentPage }}</span>
-                                    of
-                                    <span data-target="propagation.totalPageCount">{{ .propagation.totalPages }}</span>
-                                </span>
-
-                                <button data-target="propagation.nextPageButton"
-                                    data-action="click->propagation#gotoNextPage"
-                                    data-next-page="{{ .propagation.nextPage }}"
-                                    class="btn btn-link {{ if not .propagation.nextPage }}d-none{{ end }}"
-                                    Next &gt;
-                                </button>
+                                    <button data-target="propagation.nextPageButton"
+                                        data-action="click->propagation#gotoNextPage"
+                                        data-next-page="{{ .propagation.nextPage }}"
+                                        class="btn btn-link {{ if not .propagation.nextPage }}d-none{{ end }}">
+                                        Next &gt;
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -91,7 +65,7 @@
 
                 <div data-target="propagation.tablesWrapper">
                     {{/*combine view*/}}
-                    <table class="table collapsible" data-target="propagation.table" style="display: inline-block;">
+                    <table class="table collapsible mx-auto" data-target="propagation.table">
                         {{range $index, $block := .propagation.records}}
                             <tbody data-target="propagation.blocksTbody" data-block-hash="{{$block.BlockHash}}">
                             <tr>
@@ -134,8 +108,12 @@
                             {{end}}
                             </tbody>
                             <tr>
-                                <td colspan="7" height="50" style="border: none !important;"></td>
-                                <td>{{$vote.VotingOn}}</td>
+                                <td><a target="_blank"
+                                        href="https://explorer.dcrdata.org/block/{{$vote.VotingOn}}">{{$vote.VotingOn}}</a>
+                                </td>
+                                <td><a target="_blank"
+                                        href="https://explorer.dcrdata.org/block/{{$vote.BlockHash}}">...{{$vote.ShortBlockHash}}</a>
+                                </td>
                                 <td>{{$vote.ValidatorId}}</td>
                                 <td>{{$vote.Validity}}</td>
                                 <td>{{$vote.ReceiveTime}}</td>

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -88,7 +88,7 @@
                     </div>
                 </div>
 
-                <div data-target="propagation.tablesWrapper d-hide">
+                <div class="d-none" data-target="propagation.tablesWrapper">
                     {{/*combine view*/}}
                     <table class="table collapsible mx-auto" data-target="propagation.table">
                         {{range $index, $block := .propagation.records}}
@@ -134,7 +134,7 @@
                             </tbody>
                             <tbody>
                                 <tr>
-                                    <td colspan="7" height="50" style="border: none !important;"></td>
+                                    <td colspan="7" height="30" style="border: none !important;"></td>
                                 </tr>
                             </tbody>
                         {{end}}

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -2,72 +2,109 @@
 <html lang="en">
 {{ template "html-head" }}
 <body data-controller="receive">
-    <div class="body" data-controller="propagation">
-        {{ template "header" }}
-        <div class="content">
-            <div class="container"> 
-                    <div class="control-div p-0" >
-                                    <div class="d-block">
+<div class="body" data-controller="propagation">
+    {{ template "header" }}
+    <div class="content">
+        <div class="container">
 
+                <div class="control-wrapper">
+                    <div class="d-block">
                         <h4>Propagation</h4>
-</div>
-                        <div class="d-flex flex-row">
-                            <div class="chart-control control-div p-0">
-                                <select data-target="propagation.selectedRecordSet" data-action="change->propagation#selectedRecordSetChanged"
+                    </div>
+
+                    <div class="d-flex flex-row">
+                        <div class="chart-control-wrapper mr-3" data-target="propagation.chartSelector">
+                            <div class="chart-control ">
+                                <ul class="nav nav-pills">
+                                    <li class="nav-item">
+                                        <a
+                                                class="nav-link active"
+                                                href="javascript:void(0);"
+                                                data-target="propagation.viewOption"
+                                                data-action="click->propagation#setTable"
+                                                data-option="table"
+                                        >Table</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a
+                                                class="nav-link"
+                                                href="javascript:void(0);"
+                                                data-target="propagation.viewOption"
+                                                data-action="click->propagation#setChart"
+                                                data-option="chart"
+                                        >Chart</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+
+                        <div class="chart-control control-div p-0">
+                            <select data-target="propagation.selectedRecordSet"
+                                    data-action="change->propagation#selectedRecordSetChanged"
                                     class="form-control " style="width: 150px;">
-                                    <option value="both">Both</option>
-                                    <option value="blocks">Blocks</option>
-                                    <option value="votes">Votes</option>
-                                </select>
-                            </div>
+                                <option data-target="propagation.bothRecordSetOption" value="both">Both</option>
+                                <option value="blocks">Blocks</option>
+                                <option value="votes">Votes</option>
+                            </select>
+                        </div>
 
-                            <div data-target="propagation.numPageWrapper" class="control-div ml-auto p-0">
-                                <div class="control-label">Page Size:</div>
-                                <select data-target="propagation.selectedNum" data-action="change->propagation#numberOfRowsChanged" class="form-control" style="width: 70px;">
-                                    <option value="20">20</option>
-                                    <option value="30">30</option>
-                                    <option value="50">50</option>
-                                    <option value="100">100</option>
-                                    <option value="150">150</option>
-                                </select>
-                            </div>
+                        <div data-target="propagation.numPageWrapper" class="control-div ml-auto p-0">
+                            <div class="control-label">Page Size:</div>
+                            <select data-target="propagation.selectedNum"
+                                    data-action="change->propagation#numberOfRowsChanged" class="form-control"
+                                    style="width: 70px;">
+                                <option value="20">20</option>
+                                <option value="30">30</option>
+                                <option value="50">50</option>
+                                <option value="100">100</option>
+                                <option value="150">150</option>
+                            </select>
+                        </div>
 
-                            <div class="d-flex">
-                                <div class="float-md-right">
-                                    <button data-target="propagation.previousPageButton" data-action="click->propagation#gotoPreviousPage" data-previous-page="{{ .propagation.previousPage}}"
+                        <div class="d-flex" data-target="propagation.paginationButtonsWrapper">
+                            <div class="float-md-right">
+                                <button data-target="propagation.previousPageButton"
+                                        data-action="click->propagation#gotoPreviousPage"
+                                        data-previous-page="{{ .propagation.previousPage}}"
                                         class="btn btn-link {{ if lt .propagation.previousPage 1 }}d-none{{ end }}">
-                                        &lt; Previous
-                                    </button>
+                                    &lt; Previous
+                                </button>
 
-                                    <span data-target="propagation.pageReport" style="white-space: nowrap;" class="text-muted"
-                                    data-current-page="{{ .propagation.currentPage }}" style="padding-top: 6.5px;">
-                                    Page <span data-target="propagation.currentPage"
-                                    data-current-page="{{ .propagation.currentPage }}">{{ .propagation.currentPage }}</span> of
-                                    <span data-target="propagation.totalPageCount">{{ .propagation.totalPages }}</span>
-                                </span>
+                                <span data-target="propagation.pageReport" style="white-space: nowrap;" class="text-muted"
+                                      data-current-page="{{ .propagation.currentPage }}" style="padding-top: 6.5px;">
+                                        Page <span data-target="propagation.currentPage"
+                                                   data-current-page="{{ .propagation.currentPage }}">{{ .propagation.currentPage }}</span> of
+                                        <span data-target="propagation.totalPageCount">{{ .propagation.totalPages }}</span>
+                                    </span>
 
-                                <button data-target="propagation.nextPageButton" data-action="click->propagation#gotoNextPage"
-                                    data-next-page="{{ .propagation.nextPage }}" class="btn btn-link {{ if not .propagation.nextPage }}d-none{{ end }}">
+                                <button data-target="propagation.nextPageButton"
+                                        data-action="click->propagation#gotoNextPage"
+                                        data-next-page="{{ .propagation.nextPage }}"
+                                        class="btn btn-link {{ if not .propagation.nextPage }}d-none{{ end }}">
                                     Next &gt;
                                 </button>
                             </div>
                         </div>
                     </div>
+                </div>
 
+                <div data-target="propagation.tablesWrapper">
                     {{/*combine view*/}}
                     <table class="table collapsible" data-target="propagation.table" style="display: inline-block;">
                         {{range $index, $block := .propagation.records}}
-                        <tbody data-target="propagation.blocksTbody" data-block-hash="{{$block.BlockHash}}">
+                            <tbody data-target="propagation.blocksTbody" data-block-hash="{{$block.BlockHash}}">
                             <tr>
                                 <td colspan="100">
-                                    <span class="d-inline-block"><b>Height</b>: {{$block.BlockHeight}}</span>  &#8195;
-                                    <span class="d-inline-block"><b>Timestamp</b>: {{$block.BlockInternalTime}}</span>  &#8195;
-                                    <span class="d-inline-block"><b>Received</b>: {{$block.BlockReceiveTime}}</span>  &#8195;
-                                    <span class="d-inline-block"><b>Hash</b>: <a target="_blank" href="https://explorer.dcrdata.org/block/{{$block.BlockHeight}}">{{$block.BlockHash}}</a></span>
+                                    <span class="d-inline-block"><b>Height</b>: {{$block.BlockHeight}}</span> &#8195;
+                                    <span class="d-inline-block"><b>Timestamp</b>: {{$block.BlockInternalTime}}</span>
+                                    &#8195;
+                                    <span class="d-inline-block"><b>Received</b>: {{$block.BlockReceiveTime}}</span> &#8195;
+                                    <span class="d-inline-block"><b>Hash</b>: <a target="_blank"
+                                                                                 href="https://explorer.dcrdata.org/block/{{$block.BlockHeight}}">{{$block.BlockHash}}</a></span>
                                 </td>
                             </tr>
-                        </tbody>
-                        <tbody data-target="propagation.votesTbody" data-block-hash="{{$block.BlockHash}}">
+                            </tbody>
+                            <tbody data-target="propagation.votesTbody" data-block-hash="{{$block.BlockHash}}">
                             <tr style="white-space: nowrap;">
                                 <td style="width: 120px;">Voting On</td>
                                 <td style="width: 120px;">Block Hash</td>
@@ -78,33 +115,38 @@
                                 <td style="width: 120px;">Hash</td>
                             </tr>
                             {{range $index, $vote := $block.Votes}}
-                            <tr>
-                                <td><a target="_blank" href="https://explorer.dcrdata.org/block/{{$vote.VotingOn}}">{{$vote.VotingOn}}</a></td>
-                                <td><a target="_blank" href="https://explorer.dcrdata.org/block/{{$vote.BlockHash}}">...{{$vote.ShortBlockHash}}</a></td>
-                                <td>{{$vote.ValidatorId}}</td>
-                                <td>{{$vote.Validity}}</td>
-                                <td>{{$vote.ReceiveTime}}</td>
-                                <td>{{$vote.BlockReceiveTimeDiff}}s</td>
-                                <td><a target="_blank" href="https://explorer.dcrdata.org/tx/{{$vote.Hash}}">{{$vote.Hash}}</a></td>
-                            </tr>
+                                <tr>
+                                    <td><a target="_blank"
+                                           href="https://explorer.dcrdata.org/block/{{$vote.VotingOn}}">{{$vote.VotingOn}}</a>
+                                    </td>
+                                    <td><a target="_blank"
+                                           href="https://explorer.dcrdata.org/block/{{$vote.BlockHash}}">...{{$vote.ShortBlockHash}}</a>
+                                    </td>
+                                    <td>{{$vote.ValidatorId}}</td>
+                                    <td>{{$vote.Validity}}</td>
+                                    <td>{{$vote.ReceiveTime}}</td>
+                                    <td>{{$vote.BlockReceiveTimeDiff}}s</td>
+                                    <td><a target="_blank"
+                                           href="https://explorer.dcrdata.org/tx/{{$vote.Hash}}">{{$vote.Hash}}</a></td>
+                                </tr>
                             {{end}}
-                        </tbody>
-                        <tr>
-                            <td colspan="7" height="50" style="border: none !important;"></td>
-                        </tr>
+                            </tbody>
+                            <tr>
+                                <td colspan="7" height="50" style="border: none !important;"></td>
+                            </tr>
                         {{end}}
                     </table>
 
                     {{/*blocks only*/}}
                     <table class="table d-none" data-target="propagation.blocksTable">
                         <thead>
-                            <tr style="white-space: nowrap;">
-                                <th>Height</th>
-                                <th>Timestamp</th>
-                                <th>Received</th>
-                                <th>Delay</th>
-                                <th>Hash</th>
-                            </tr>
+                        <tr style="white-space: nowrap;">
+                            <th>Height</th>
+                            <th>Timestamp</th>
+                            <th>Received</th>
+                            <th>Delay</th>
+                            <th>Hash</th>
+                        </tr>
                         </thead>
                         <tbody data-target="propagation.blocksTableBody">
                         </tbody>
@@ -123,16 +165,16 @@
                     {{/*votes only*/}}
                     <table data-target="propagation.votesTable" class="table d-none">
                         <thead>
-                            <tr style="white-space: nowrap;">
-                                <th>Voting On</th>
-                                <th>Block Hash</th>
-                                <th>Validator ID</th>
-                                <th>Validity</th>
-                                <th>Received</th>
-                                <th>Block Time Diff</th>
-                                <th>Block Receive Time Diff</th>
-                                <th>Hash</th>
-                            </tr>
+                        <tr style="white-space: nowrap;">
+                            <th>Voting On</th>
+                            <th>Block Hash</th>
+                            <th>Validator ID</th>
+                            <th>Validity</th>
+                            <th>Received</th>
+                            <th>Block Time Diff</th>
+                            <th>Block Receive Time Diff</th>
+                            <th>Hash</th>
+                        </tr>
                         </thead>
                         <tbody data-target="propagation.votesTableBody">
                         </tbody>
@@ -151,9 +193,16 @@
                         </tr>
                     </template>
                 </div>
-            </div>
+
+                <div data-target="propagation.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-hide" style="width:100%;">
+                    <div id="chart" data-target="propagation.chartsView" style="width:100%; height:73vh; margin:0 auto;"></div>
+                    <div class="d-flex justify-content-center legend-wrapper">
+                        <div class="legend d-flex" data-target="propagation.labels"></div>
+                    </div>
+                </div>
         </div>
     </div>
+</div>
 </div>
 {{ template "footer" }}
 </body>

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -52,7 +52,7 @@
                                 </select>
                             </div>
 
-                            <div data-target="vsp.numPageWrapper" class="control-div p-0 ml-5">
+                            <div data-target="vsp.numPageWrapper" class="control-div p-0 ml-1">
                                 <div class=" mb-2 float-md-right">
                                     <div class="control-label">Page Size:</div>
                                     <select data-target="vsp.selectedNum" data-action="change->vsp#numberOfRowsChanged"

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -8,23 +8,24 @@
         <div class="content">
             <div class="container-fluid">
                 <div class="control-wrapper">
-                    <div class="chart-control-wrapper mb-2" data-target="vsp.chartSelector">
-                        <div class="chart-control mx-auto">
+                    <!-- <div class="chart-control-wrapper mb-2" data-target="vsp.chartSelector">
+                       
+                    </div> -->
+
+                    <div class="d-flex flex-row">
+                        <div class="chart-control ml-auto mr-3">
                             <ul class="nav nav-pills">
                                 <li class="nav-item">
                                     <a class="nav-link active" href="javascript:void(0);" data-target="vsp.viewOption"
-                                        data-action="click->vsp#setTable" data-option="table">Table</a>
+                                        data-action="click->vsp#setChart" data-option="chart">Chart</a>
                                 </li>
                                 <li class="nav-item">
                                     <a class="nav-link" href="javascript:void(0);" data-target="vsp.viewOption"
-                                        data-action="click->vsp#setChart" data-option="chart">Chart</a>
+                                        data-action="click->vsp#setTable" data-option="table">Table</a>
                                 </li>
                             </ul>
                         </div>
-                    </div>
-
-                    <div class="d-flex flex-row">
-                        <div class="mx-auto d-flex">
+                        <div class="mr-auto d-flex">
                             <div class="control-div p-0" data-target="vsp.vspSelectorWrapper">
                                 <div class="control-label">VSP:</div>
                                 <select data-target="vsp.selectedFilter" data-action="change->vsp#selectedFilterChanged"
@@ -87,7 +88,7 @@
                     </div>
                 </div>
 
-                <div class="" data-target="vsp.vspTableWrapper">
+                <div class="d-none" data-target="vsp.vspTableWrapper">
                     <table class="table mx-auto">
                         <thead>
                             <tr>
@@ -140,7 +141,7 @@
                     </template>
                 </div>
 
-                <div data-target="vsp.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-none">
+                <div data-target="vsp.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5">
                     <div class="row">
                         <div class="col-sm-3 side-vsp-panel">
                             <div class="p-0 d-none" data-target="vsp.chartSourceWrapper">

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -8,10 +8,6 @@
         <div class="content">
             <div class="container-fluid">
                 <div class="control-wrapper">
-                    <!-- <div class="chart-control-wrapper mb-2" data-target="vsp.chartSelector">
-                       
-                    </div> -->
-
                     <div class="d-flex flex-row">
                         <div class="chart-control ml-auto mr-3">
                             <ul class="nav nav-pills">
@@ -84,7 +80,6 @@
                                     Next&gt;</a>
                             </div>
                         </div>
-                        
                     </div>
                 </div>
 
@@ -175,5 +170,4 @@
     </div>
     {{ template "footer" }}
 </body>
-
 </html>

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -1,172 +1,175 @@
 <!DOCTYPE html>
 <html lang="en">
 {{ template "html-head" }}
+
 <body>
     <div class="body" data-controller="vsp">
         {{ template "header" }}
         <div class="content">
-            <div class="container">
+            <div class="container-fluid">
                 <div class="control-wrapper">
                     <div class="chart-control-wrapper mb-2" data-target="vsp.chartSelector">
                         <div class="chart-control">
                             <ul class="nav nav-pills">
-                            <li class="nav-item">
-                                <a
-                                class="nav-link active"
-                                href="javascript:void(0);"
-                                data-target="vsp.viewOption"
-                                data-action="click->vsp#setTable"
-                                data-option="table"
-                                >Table</a>
-                            </li>
-                            <li class="nav-item">
-                                <a
-                                class="nav-link"
-                                href="javascript:void(0);"
-                                data-target="vsp.viewOption"
-                                data-action="click->vsp#setChart"
-                                data-option="chart"
-                                >Chart</a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="d-flex flex-row">
-                    <div class="control-div p-0" data-target="vsp.vspSelectorWrapper">
-                        <div class="control-label">VSP:</div>
-                        <select data-target="vsp.selectedFilter" data-action="change->vsp#selectedFilterChanged"
-                            class="form-control" style="width: 278px;">
-                            {{$selectedFilter := .selectedFilter}}
-                            <option value="All">All</option>
-
-                            {{ range $index, $filter := .allVspData}}
-                            <option value="{{$filter.Name}}" {{ if eq $filter.Name $selectedFilter}} selected {{ end }}>{{$filter.Host}} ({{$filter.Name}})</option>
-                            {{ end }}
-                        </select>
+                                <li class="nav-item">
+                                    <a class="nav-link active" href="javascript:void(0);" data-target="vsp.viewOption"
+                                        data-action="click->vsp#setTable" data-option="table">Table</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="javascript:void(0);" data-target="vsp.viewOption"
+                                        data-action="click->vsp#setChart" data-option="chart">Chart</a>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
 
-                    <div data-target="vsp.graphTypeWrapper" class="control-div p-0 d-none ">
-                        <div class="control-label">Data:</div>
-                        <select data-target="vsp.graphType" data-action="change->vsp#graphTypeChanged"
-                            class="form-control" style="width: 150px;">
-                            <option value="Immature">Immature</option>
-                            <option value="Live">Live</option>
-                            <option value="Voted">Voted</option>
-                            <option value="Missed">Missed</option>
-                            <option value="Pool_Fees">Pool Fees</option>
-                            <option value="Proportion_Live">Proportion Live</option>
-                            <option value="Proportion_Missed">Proportion Missed</option>
-                            <option value="User_Count">User Count</option>
-                            <option value="Users_Active">Users Active</option>
-                        </select>
-                    </div>
+                    <div class="d-flex flex-row">
+                        <div class="control-div p-0" data-target="vsp.vspSelectorWrapper">
+                            <div class="control-label">VSP:</div>
+                            <select data-target="vsp.selectedFilter" data-action="change->vsp#selectedFilterChanged"
+                                class="form-control" style="width: 278px;">
+                                {{$selectedFilter := .selectedFilter}}
+                                <option value="All">All</option>
 
-                    <div data-target="vsp.numPageWrapper" class="control-div p-0 ml-auto">
-                        <div class=" mb-2 float-md-right">
-                            <div class="control-label">Page Size:</div>
-                            <select data-target="vsp.selectedNum" data-action="change->vsp#numberOfRowsChanged" class="form-control" style="width: 70px;">
-                                <option value="20">20</option>
-                                <option value="30">30</option>
-                                <option value="50">50</option>
-                                <option value="100">100</option>
-                                <option value="150">150</option>
+                                {{ range $index, $filter := .allVspData}}
+                                <option value="{{$filter.Name}}" {{ if eq $filter.Name $selectedFilter}} selected
+                                    {{ end }}>{{$filter.Host}} ({{$filter.Name}})</option>
+                                {{ end }}
                             </select>
                         </div>
-                    </div>
+
+                        <div data-target="vsp.graphTypeWrapper" class="control-div p-0 d-none ">
+                            <div class="control-label">Data:</div>
+                            <select data-target="vsp.graphType" data-action="change->vsp#graphTypeChanged"
+                                class="form-control" style="width: 150px;">
+                                <option value="Immature">Immature</option>
+                                <option value="Live">Live</option>
+                                <option value="Voted">Voted</option>
+                                <option value="Missed">Missed</option>
+                                <option value="Pool_Fees">Pool Fees</option>
+                                <option value="Proportion_Live">Proportion Live</option>
+                                <option value="Proportion_Missed">Proportion Missed</option>
+                                <option value="User_Count">User Count</option>
+                                <option value="Users_Active">Users Active</option>
+                            </select>
+                        </div>
+
+                        <div data-target="vsp.numPageWrapper" class="control-div p-0 ml-auto">
+                            <div class=" mb-2 float-md-right">
+                                <div class="control-label">Page Size:</div>
+                                <select data-target="vsp.selectedNum" data-action="change->vsp#numberOfRowsChanged"
+                                    class="form-control" style="width: 70px;">
+                                    <option value="20">20</option>
+                                    <option value="30">30</option>
+                                    <option value="50">50</option>
+                                    <option value="100">100</option>
+                                    <option value="150">150</option>
+                                </select>
+                            </div>
+                        </div>
                         <div data-target="vsp.pageSizeWrapper" class="d-flex">
-                            <a href="javascript:void(0)" data-target="vsp.previousPageButton" data-action="click->vsp#loadPreviousPage" data-next-page="{{ .previousPage }}" class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
+                            <a href="javascript:void(0)" data-target="vsp.previousPageButton"
+                                data-action="click->vsp#loadPreviousPage" data-next-page="{{ .previousPage }}"
+                                class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
 
-                            <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="vsp.currentPage" class="text-muted"> {{ .currentPage }}</span> of <span data-target="vsp.totalPageCount" class="text-muted">{{ .totalPages }}</span>
+                            <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="vsp.currentPage"
+                                    class="text-muted"> {{ .currentPage }}</span> of <span
+                                    data-target="vsp.totalPageCount" class="text-muted">{{ .totalPages }}</span>
                             </p>
-                            <a href="javascript:void(0)" data-target="vsp.nextPageButton" data-action="click->vsp#loadNextPage" data-total-page="{{ .totalPages }}" data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}"> Next&gt;</a>
+                            <a href="javascript:void(0)" data-target="vsp.nextPageButton"
+                                data-action="click->vsp#loadNextPage" data-total-page="{{ .totalPages }}"
+                                data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}">
+                                Next&gt;</a>
                         </div>
                     </div>
                 </div>
 
-            <div class="" data-target="vsp.vspTableWrapper">
-                <table class="table">
-                    <thead>
-                    <tr>
-                        <th>VSP</th>
-                        <th>Immature</th>
-                        <th>Live</th>
-                        <th>Voted</th>
-                        <th>Missed</th>
-                        <th>Pool Fees</th>
-                        <th>% Live</th>
-                        <th>% Missed</th>
-                        <th>User Count</th>
-                        <th>Users Active</th>
-                        <th>Time(UTC)</th>
-                    </tr>
-                    </thead>
-                    <tbody data-target="vsp.vspTicksTable">
-                    {{range $index, $vspticks := .vspData}}
+                <div class="" data-target="vsp.vspTableWrapper">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>VSP</th>
+                                <th>Immature</th>
+                                <th>Live</th>
+                                <th>Voted</th>
+                                <th>Missed</th>
+                                <th>Pool Fees</th>
+                                <th>% Live</th>
+                                <th>% Missed</th>
+                                <th>User Count</th>
+                                <th>Users Active</th>
+                                <th>Time(UTC)</th>
+                            </tr>
+                        </thead>
+                        <tbody data-target="vsp.vspTicksTable">
+                            {{range $index, $vspticks := .vspData}}
+                            <tr>
+                                <td>{{$vspticks.VSP}}</td>
+                                <td>{{$vspticks.Immature}}</td>
+                                <td>{{$vspticks.Live}}</td>
+                                <td>{{$vspticks.Voted}}</td>
+                                <td>{{$vspticks.Missed}}</td>
+                                <td>{{$vspticks.PoolFees}}</td>
+                                <td>{{$vspticks.ProportionLive}}</td>
+                                <td>{{$vspticks.ProportionMissed}}</td>
+                                <td>{{$vspticks.UserCount}}</td>
+                                <td>{{$vspticks.UsersActive}}</td>
+                                <td>{{$vspticks.Time}}</td>
+                            </tr>
+                            {{end}}
+                        </tbody>
+                    </table>
+
+                    <template data-target="vsp.vspRowTemplate">
                         <tr>
-                            <td>{{$vspticks.VSP}}</td>
-                            <td>{{$vspticks.Immature}}</td>
-                            <td>{{$vspticks.Live}}</td>
-                            <td>{{$vspticks.Voted}}</td>
-                            <td>{{$vspticks.Missed}}</td>
-                            <td>{{$vspticks.PoolFees}}</td>
-                            <td>{{$vspticks.ProportionLive}}</td>
-                            <td>{{$vspticks.ProportionMissed}}</td>
-                            <td>{{$vspticks.UserCount}}</td>
-                            <td>{{$vspticks.UsersActive}}</td>
-                            <td>{{$vspticks.Time}}</td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
                         </tr>
-                    {{end}}
-                    </tbody>
-                </table>
-
-                <template data-target="vsp.vspRowTemplate">
-                    <tr>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                    </tr>
-                </template>
-            </div>
-
-            <div data-target="vsp.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-none">
-                <div class="row">
-                    <div class="col-sm-3 side-vsp-panel">
-                        <div class="p-0 d-none" data-target="vsp.chartSourceWrapper">
-                            {{ range $index, $filter := .allVspData}}
-                                <div class="form-check form-check-inline">
-                                    <input name="chartSource" data-target="vsp.chartSource" data-action="click->vsp#chartSourceCheckChanged"
-                                           class="form-check-input" type="checkbox" id="inlineCheckbox-{{$filter.Name}}"
-                                           value="{{$filter.Name}}" {{ if eq $index 0 }} checked {{ end }}>
-                                    <label class="form-check-label" for="inlineCheckbox-{{$filter.Name}}">{{$filter.Host}} ({{$filter.Name}})</label>
-                                </div>
-                            {{ end }}
-                        </div>
-                    </div>
-
-                    <div class="col-md-9 chart-panel">
-                        <div id="chart"
-                             data-target="vsp.chartsView"
-                             style="width:100%; height:73vh; margin:0 auto;">
-                    </div>
+                    </template>
                 </div>
 
-            </div>
-            <div class="d-flex justify-content-center legend-wrapper">
-                <div class="legend d-flex" data-target="vsp.labels"></div>
+                <div data-target="vsp.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5 d-none">
+                    <div class="row">
+                        <div class="col-sm-3 side-vsp-panel">
+                            <div class="p-0 d-none" data-target="vsp.chartSourceWrapper">
+                                {{ range $index, $filter := .allVspData}}
+                                <div class="form-check form-check-inline">
+                                    <input name="chartSource" data-target="vsp.chartSource"
+                                        data-action="click->vsp#chartSourceCheckChanged" class="form-check-input"
+                                        type="checkbox" id="inlineCheckbox-{{$filter.Name}}" value="{{$filter.Name}}"
+                                        {{ if eq $index 0 }} checked {{ end }}>
+                                    <label class="form-check-label"
+                                        for="inlineCheckbox-{{$filter.Name}}">{{$filter.Host}}
+                                        ({{$filter.Name}})</label>
+                                </div>
+                                {{ end }}
+                            </div>
+                        </div>
+
+                        <div class="col-md-9 chart-panel">
+                            <div id="chart" data-target="vsp.chartsView"
+                                style="width:100%; height:73vh; margin:0 auto;">
+                            </div>
+                        </div>
+
+                    </div>
+                    <div class="d-flex justify-content-center legend-wrapper">
+                        <div class="legend d-flex" data-target="vsp.labels"></div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
-</div>
-</div>
-{{ template "footer" }}
+    {{ template "footer" }}
 </body>
+
 </html>

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -9,7 +9,7 @@
             <div class="container-fluid">
                 <div class="control-wrapper">
                     <div class="chart-control-wrapper mb-2" data-target="vsp.chartSelector">
-                        <div class="chart-control">
+                        <div class="chart-control mx-auto">
                             <ul class="nav nav-pills">
                                 <li class="nav-item">
                                     <a class="nav-link active" href="javascript:void(0);" data-target="vsp.viewOption"
@@ -24,68 +24,71 @@
                     </div>
 
                     <div class="d-flex flex-row">
-                        <div class="control-div p-0" data-target="vsp.vspSelectorWrapper">
-                            <div class="control-label">VSP:</div>
-                            <select data-target="vsp.selectedFilter" data-action="change->vsp#selectedFilterChanged"
-                                class="form-control" style="width: 278px;">
-                                {{$selectedFilter := .selectedFilter}}
-                                <option value="All">All</option>
+                        <div class="mx-auto d-flex">
+                            <div class="control-div p-0" data-target="vsp.vspSelectorWrapper">
+                                <div class="control-label">VSP:</div>
+                                <select data-target="vsp.selectedFilter" data-action="change->vsp#selectedFilterChanged"
+                                    class="form-control" style="width: 278px;">
+                                    {{$selectedFilter := .selectedFilter}}
+                                    <option value="All">All</option>
 
-                                {{ range $index, $filter := .allVspData}}
-                                <option value="{{$filter.Name}}" {{ if eq $filter.Name $selectedFilter}} selected
-                                    {{ end }}>{{$filter.Host}} ({{$filter.Name}})</option>
-                                {{ end }}
-                            </select>
-                        </div>
-
-                        <div data-target="vsp.graphTypeWrapper" class="control-div p-0 d-none ">
-                            <div class="control-label">Data:</div>
-                            <select data-target="vsp.graphType" data-action="change->vsp#graphTypeChanged"
-                                class="form-control" style="width: 150px;">
-                                <option value="Immature">Immature</option>
-                                <option value="Live">Live</option>
-                                <option value="Voted">Voted</option>
-                                <option value="Missed">Missed</option>
-                                <option value="Pool_Fees">Pool Fees</option>
-                                <option value="Proportion_Live">Proportion Live</option>
-                                <option value="Proportion_Missed">Proportion Missed</option>
-                                <option value="User_Count">User Count</option>
-                                <option value="Users_Active">Users Active</option>
-                            </select>
-                        </div>
-
-                        <div data-target="vsp.numPageWrapper" class="control-div p-0 ml-auto">
-                            <div class=" mb-2 float-md-right">
-                                <div class="control-label">Page Size:</div>
-                                <select data-target="vsp.selectedNum" data-action="change->vsp#numberOfRowsChanged"
-                                    class="form-control" style="width: 70px;">
-                                    <option value="20">20</option>
-                                    <option value="30">30</option>
-                                    <option value="50">50</option>
-                                    <option value="100">100</option>
-                                    <option value="150">150</option>
+                                    {{ range $index, $filter := .allVspData}}
+                                    <option value="{{$filter.Name}}" {{ if eq $filter.Name $selectedFilter}} selected
+                                        {{ end }}>{{$filter.Host}} ({{$filter.Name}})</option>
+                                    {{ end }}
                                 </select>
                             </div>
-                        </div>
-                        <div data-target="vsp.pageSizeWrapper" class="d-flex">
-                            <a href="javascript:void(0)" data-target="vsp.previousPageButton"
-                                data-action="click->vsp#loadPreviousPage" data-next-page="{{ .previousPage }}"
-                                class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
 
-                            <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="vsp.currentPage"
-                                    class="text-muted"> {{ .currentPage }}</span> of <span
-                                    data-target="vsp.totalPageCount" class="text-muted">{{ .totalPages }}</span>
-                            </p>
-                            <a href="javascript:void(0)" data-target="vsp.nextPageButton"
-                                data-action="click->vsp#loadNextPage" data-total-page="{{ .totalPages }}"
-                                data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}">
-                                Next&gt;</a>
+                            <div data-target="vsp.graphTypeWrapper" class="control-div p-0 d-none ">
+                                <div class="control-label">Data:</div>
+                                <select data-target="vsp.graphType" data-action="change->vsp#graphTypeChanged"
+                                    class="form-control" style="width: 150px;">
+                                    <option value="Immature">Immature</option>
+                                    <option value="Live">Live</option>
+                                    <option value="Voted">Voted</option>
+                                    <option value="Missed">Missed</option>
+                                    <option value="Pool_Fees">Pool Fees</option>
+                                    <option value="Proportion_Live">Proportion Live</option>
+                                    <option value="Proportion_Missed">Proportion Missed</option>
+                                    <option value="User_Count">User Count</option>
+                                    <option value="Users_Active">Users Active</option>
+                                </select>
+                            </div>
+
+                            <div data-target="vsp.numPageWrapper" class="control-div p-0 ml-5">
+                                <div class=" mb-2 float-md-right">
+                                    <div class="control-label">Page Size:</div>
+                                    <select data-target="vsp.selectedNum" data-action="change->vsp#numberOfRowsChanged"
+                                        class="form-control" style="width: 70px;">
+                                        <option value="20">20</option>
+                                        <option value="30">30</option>
+                                        <option value="50">50</option>
+                                        <option value="100">100</option>
+                                        <option value="150">150</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div data-target="vsp.pageSizeWrapper" class="d-inline pt-1">
+                                <a href="javascript:void(0)" data-target="vsp.previousPageButton"
+                                    data-action="click->vsp#loadPreviousPage" data-next-page="{{ .previousPage }}"
+                                    class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
+
+                                <p class="text-muted d-inline" style="white-space: nowrap;"> Page <span data-target="vsp.currentPage"
+                                        class="text-muted"> {{ .currentPage }}</span> of <span
+                                        data-target="vsp.totalPageCount" class="text-muted">{{ .totalPages }}</span>
+                                </p>
+                                <a href="javascript:void(0)" data-target="vsp.nextPageButton"
+                                    data-action="click->vsp#loadNextPage" data-total-page="{{ .totalPages }}"
+                                    data-next-page="{{ .nextPage }}" class="ml-2 {{ if not .nextPage }}d-none{{ end }}">
+                                    Next&gt;</a>
+                            </div>
                         </div>
+                        
                     </div>
                 </div>
 
                 <div class="" data-target="vsp.vspTableWrapper">
-                    <table class="table">
+                    <table class="table mx-auto">
                         <thead>
                             <tr>
                                 <th>VSP</th>

--- a/web/views/vsp.html
+++ b/web/views/vsp.html
@@ -65,7 +65,7 @@
                                     </select>
                                 </div>
                             </div>
-                            <div data-target="vsp.pageSizeWrapper" class="d-inline pt-1">
+                            <div data-target="vsp.pageSizeWrapper" class="d-inline pt-1 control-div">
                                 <a href="javascript:void(0)" data-target="vsp.previousPageButton"
                                     data-action="click->vsp#loadPreviousPage" data-next-page="{{ .previousPage }}"
                                     class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>


### PR DESCRIPTION
**It fixes issue #109** 

--Made the table adjust to data width and the chart to expand to fill available page space on all pages.
--Switched position of tables and charts in selector on all pages.
--Made chart default view for all pages with chart view.
--Changed order of menu items

![image](https://user-images.githubusercontent.com/15652001/62086811-7c5ed780-b257-11e9-81cd-b9ddfcf014ab.png)
![image](https://user-images.githubusercontent.com/15652001/62086843-939dc500-b257-11e9-9cbb-72f348b178e8.png)

![image](https://user-images.githubusercontent.com/15652001/62091274-0747ce00-b268-11e9-9b44-f3ebff046cc4.png)

![image](https://user-images.githubusercontent.com/15652001/62091322-2e060480-b268-11e9-8a70-356ccdcc5ccf.png)

![image](https://user-images.githubusercontent.com/15652001/62091344-4413c500-b268-11e9-88a8-ef54b4395e28.png)



--Made 1D selected by default for interval in exchanges view.

![image](https://user-images.githubusercontent.com/15652001/62086901-be881900-b257-11e9-82d6-47290452e3f9.png)


--Fixed typo in sample-config
![image](https://user-images.githubusercontent.com/15652001/62087005-1030a380-b258-11e9-92c8-14e33a199105.png)

![image](https://user-images.githubusercontent.com/15652001/62091350-52fa7780-b268-11e9-894e-87d37f90841b.png)

