### PR TITLE
Propagation page modification.

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -882,7 +882,7 @@ func (s *Server) fetchPropagationData(req *http.Request) (map[string]interface{}
 
 	ctx := req.Context()
 
-	if viewOption == "" || viewOption == "chart" {
+	if viewOption == "chart" {
 		data := map[string]interface{}{
 			"chartView":          true,
 			"selectedViewOption": defaultViewOption,

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -220,6 +220,7 @@ export default class extends Controller {
         dateWindow: [minDate, maxDate],
         legendFormatter: legendFormatter,
         plotter: barChartPlotter,
+        digitsAfterDecimal: 8,
         labelsDiv: _this.labelsTarget,
         ylabel: title,
         xlabel: 'Date',

--- a/web/public/app/src/controllers/propagation_controller.js
+++ b/web/public/app/src/controllers/propagation_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from 'stimulus'
 import axios from 'axios'
-import { hide, show, setActiveOptionBtn, legendFormatter, showLoading, hideLoading, displayPillBtnOption } from '../utils'
+import { hide, show, setActiveOptionBtn, legendFormatter, showLoading, hideLoading, displayPillBtnOption, setActiveRecordSetBtn } from '../utils'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
 
@@ -38,39 +38,27 @@ export default class extends Controller {
 
   setTable () {
     this.selectedViewOption = 'table'
-    setActiveOptionBtn(this.selectedViewOption, this.viewOptionTargets)
-    this.selectedRecordSetTargets.forEach(li => {
-      if (li.dataset.option === 'both') {
-        li.classList.add('active')
-      } else {
-        li.classList.remove('active')
-      }
-    })
     this.selectedRecordSet = 'both'
     hide(this.chartWrapperTarget)
     show(this.paginationButtonsWrapperTarget)
     show(this.numPageWrapperTarget)
     hide(this.chartWrapperTarget)
     show(this.tablesWrapperTarget)
+    setActiveOptionBtn(this.selectedViewOption, this.viewOptionTargets)
+    setActiveRecordSetBtn(this.selectedRecordSet, this.selectedRecordSetTargets)
     displayPillBtnOption(this.selectedViewOption, this.selectedRecordSetTargets)
     this.fetchTableData(this.currentPage)
   }
 
   setChart () {
     this.selectedViewOption = 'chart'
-    setActiveOptionBtn(this.selectedViewOption, this.viewOptionTargets)
+    this.selectedRecordSet = 'blocks'
     hide(this.numPageWrapperTarget)
     hide(this.paginationButtonsWrapperTarget)
     hide(this.tablesWrapperTarget)
     show(this.chartWrapperTarget)
-    this.selectedRecordSetTargets.forEach(li => {
-      if (li.dataset.option === 'blocks') {
-        li.classList.add('active')
-      } else {
-        li.classList.remove('active')
-      }
-    })
-    this.selectedRecordSet = 'blocks'
+    setActiveOptionBtn(this.selectedViewOption, this.viewOptionTargets)
+    setActiveRecordSetBtn(this.selectedRecordSet, this.selectedRecordSetTargets)
     displayPillBtnOption(this.selectedViewOption, this.selectedRecordSetTargets)
     this.fetchChartDataAndPlot()
   }

--- a/web/public/app/src/controllers/propagation_controller.js
+++ b/web/public/app/src/controllers/propagation_controller.js
@@ -1,14 +1,13 @@
 import { Controller } from 'stimulus'
 import axios from 'axios'
-import { hide, show, setActiveOptionBtn, legendFormatter, showLoading, hideLoading } from '../utils'
+import { hide, show, setActiveOptionBtn, legendFormatter, showLoading, hideLoading, displayPillBtnOption } from '../utils'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
 
 export default class extends Controller {
   static get targets () {
     return [
-      'nextPageButton', 'previousPageButton',
-      'bothRecordSetOption', 'selectedRecordSet', 'selectedNum', 'numPageWrapper', 'paginationButtonsWrapper',
+      'nextPageButton', 'previousPageButton', 'recordSetSelector', 'bothRecordSetOption', 'selectedRecordSet', 'selectedNum', 'numPageWrapper', 'paginationButtonsWrapper',
       'tablesWrapper', 'table', 'blocksTbody', 'votesTbody', 'chartWrapper', 'chartsView', 'labels',
       'blocksTable', 'blocksTableBody', 'blocksRowTemplate', 'votesTable', 'votesTableBody', 'votesRowTemplate',
       'totalPageCount', 'currentPage', 'viewOptionControl', 'chartSelector', 'viewOption', 'loadingData'
@@ -21,6 +20,14 @@ export default class extends Controller {
       this.currentPage = 1
     }
 
+    this.selectedRecordSetTargets.forEach(li => {
+      if (this.selectedViewOption === 'table' && li.dataset.option === 'both') {
+        li.classList.add('active')
+      } else {
+        li.classList.remove('active')
+      }
+    })
+
     this.selectedViewOption = this.viewOptionControlTarget.getAttribute('data-initial-value')
     if (this.selectedViewOption === 'chart') {
       this.setChart()
@@ -31,58 +38,93 @@ export default class extends Controller {
 
   setTable () {
     this.selectedViewOption = 'table'
-    this.selectedRecordSet = this.selectedRecordSetTarget.value = this.selectedRecordSetTarget.options[0].value
     setActiveOptionBtn(this.selectedViewOption, this.viewOptionTargets)
-    show(this.selectedRecordSetTarget.options[0])
-    this.selectedRecordSet = this.selectedRecordSetTarget.value
+    this.selectedRecordSetTargets.forEach(li => {
+      if (li.dataset.option === 'both') {
+        li.classList.add('active')
+      } else {
+        li.classList.remove('active')
+      }
+    })
+    this.selectedRecordSet = 'both'
     hide(this.chartWrapperTarget)
-    show(this.bothRecordSetOptionTarget)
     show(this.paginationButtonsWrapperTarget)
     show(this.numPageWrapperTarget)
     hide(this.chartWrapperTarget)
     show(this.tablesWrapperTarget)
-    this.fetchData(this.currentPage)
+    displayPillBtnOption(this.selectedViewOption, this.selectedRecordSetTargets)
+    this.fetchTableData(this.currentPage)
   }
 
   setChart () {
     this.selectedViewOption = 'chart'
     setActiveOptionBtn(this.selectedViewOption, this.viewOptionTargets)
-    hide(this.selectedRecordSetTarget.options[0])
     hide(this.numPageWrapperTarget)
     hide(this.paginationButtonsWrapperTarget)
     hide(this.tablesWrapperTarget)
     show(this.chartWrapperTarget)
-    this.selectedRecordSet = this.selectedRecordSetTarget.value = this.selectedRecordSetTarget.options[1].value
-
+    this.selectedRecordSetTargets.forEach(li => {
+      if (li.dataset.option === 'blocks') {
+        li.classList.add('active')
+      } else {
+        li.classList.remove('active')
+      }
+    })
+    this.selectedRecordSet = 'blocks'
+    displayPillBtnOption(this.selectedViewOption, this.selectedRecordSetTargets)
     this.fetchChartDataAndPlot()
   }
 
-  selectedRecordSetChanged () {
+  setBothRecordSet () {
+    this.selectedRecordSet = 'both'
+    setActiveOptionBtn(this.selectedRecordSet, this.selectedRecordSetTargets)
     this.currentPage = 1
     this.selectedNumTarget.value = this.selectedNumTarget.options[0].text
-    this.selectedRecordSet = this.selectedRecordSetTarget.value
     if (this.selectedViewOption === 'table') {
-      this.fetchData(1)
+      this.fetchTableData(1)
+    } else {
+      this.fetchChartDataAndPlot()
+    }
+  }
+
+  setBlocksRecordSet () {
+    this.selectedRecordSet = 'blocks'
+    setActiveOptionBtn(this.selectedRecordSet, this.selectedRecordSetTargets)
+    this.currentPage = 1
+    this.selectedNumTarget.value = this.selectedNumTarget.options[0].text
+    if (this.selectedViewOption === 'table') {
+      this.fetchTableData(1)
+    } else {
+      this.fetchChartDataAndPlot()
+    }
+  }
+
+  setVotesRecordSet () {
+    this.selectedRecordSet = 'votes'
+    setActiveOptionBtn(this.selectedRecordSet, this.selectedRecordSetTargets)
+    this.currentPage = 1
+    this.selectedNumTarget.value = this.selectedNumTarget.options[0].text
+    if (this.selectedViewOption === 'table') {
+      this.fetchTableData(1)
     } else {
       this.fetchChartDataAndPlot()
     }
   }
 
   loadPreviousPage () {
-    this.fetchData(this.currentPage - 1)
+    this.fetchTableData(this.currentPage - 1)
   }
 
   loadNextPage () {
-    this.fetchData(this.currentPage + 1)
+    this.fetchTableData(this.currentPage + 1)
   }
 
   numberOfRowsChanged () {
-    this.selectedRecordSet = this.selectedRecordSetTarget.value
     this.selectedNum = this.selectedNumTarget.value
-    this.fetchData(1)
+    this.fetchTableData(1)
   }
 
-  fetchData (page) {
+  fetchTableData (page) {
     const _this = this
 
     let elementsToToggle = [this.tablesWrapperTarget]
@@ -104,7 +146,6 @@ export default class extends Controller {
     axios.get(`/${url}?page=${page}&recordsPerPage=${numberOfRows}&viewOption=${_this.selectedViewOption}`).then(function (response) {
       hideLoading(_this.loadingDataTarget, elementsToToggle)
       let result = response.data
-      console.log(result)
       _this.totalPageCountTarget.textContent = result.totalPages
       _this.currentPageTarget.textContent = result.currentPage
       window.history.pushState(window.history.state, _this.addr, `${result.url}?page=${result.currentPage}&recordsPerPage=${result.selectedNum}&viewOption=${_this.selectedViewOption}`)

--- a/web/public/app/src/utils.js
+++ b/web/public/app/src/utils.js
@@ -148,3 +148,13 @@ export function setActiveOptionBtn (opt, optTargets) {
     }
   })
 }
+
+export function displayPillBtnOption (opt, optTargets) {
+  optTargets.forEach(li => {
+    if (opt === 'chart' && li.dataset.option === 'both') {
+      li.classList.add('d-hide')
+    } else {
+      li.classList.remove('d-hide')
+    }
+  })
+}

--- a/web/public/app/src/utils.js
+++ b/web/public/app/src/utils.js
@@ -149,6 +149,16 @@ export function setActiveOptionBtn (opt, optTargets) {
   })
 }
 
+export function setActiveRecordSetBtn (opt, optTargets) {
+  optTargets.forEach(li => {
+    if (li.dataset.option === opt) {
+      li.classList.add('active')
+    } else {
+      li.classList.remove('active')
+    }
+  })
+}
+
 export function displayPillBtnOption (opt, optTargets) {
   optTargets.forEach(li => {
     if (opt === 'chart' && li.dataset.option === 'both') {

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -8,125 +8,146 @@
         <div class="content">
             <div class="container-fluid">
                 <div class="control-div p-0">
-                    <div class="d-flex flex-row mb-3 mt-1">
-                        <div class="mx-auto d-flex">
-                            <div class="chart-control-wrapper mr-3" data-target="propagation.chartSelector">
-                                <div class="chart-control " data-target="propagation.viewOptionControl" data-initial-value="{{ .propagation.selectedViewOption }}">
-                                    <ul class="nav nav-pills">
-                                        <li class="nav-item">
-                                            <a
-                                                    class="nav-link active"
-                                                    href="javascript:void(0);"
-                                                    data-target="propagation.viewOption"
-                                                    data-action="click->propagation#setChart"
-                                                    data-option="chart"
-                                            >Chart</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a
-                                                    class="nav-link"
-                                                    href="javascript:void(0);"
-                                                    data-target="propagation.viewOption"
-                                                    data-action="click->propagation#setTable"
-                                                    data-option="table"
-                                            >Table</a>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="chart-control control-div p-0">
-                                <select data-target="propagation.selectedRecordSet" data-action="change->propagation#selectedRecordSetChanged"
-                                    class="form-control " style="width: 150px;">
-                                    {{$selectedFilter := .propagation.selectedFilter}}
-                                    <option data-target="propagation.bothRecordSetOption" value="both">Both</option>
-                                    {{ range $index, $filter := .propagation.propagationFilter}}
-                                    <option value="{{$index}}" {{ if eq $index $selectedFilter}} selected {{ end }}>{{$filter}}</option>
-                                    {{ end }}
-                                </select>
-                            </div>
+                    <div class="d-flex flex-row mb-3 mt-1 mx-auto j">
+                        <div class="offset-md-4 mr-3 d-flex">
+                            <div class="chart-control " data-target="propagation.viewOptionControl" data-initial-value="{{ .propagation.selectedViewOption }}">
+                                <ul class="nav nav-pills">
+                                    <li class="nav-item">
+                                        <a
+                                        class="nav-link active"
+                                        href="javascript:void(0);"
+                                        data-target="propagation.viewOption"
+                                        data-action="click->propagation#setTable"
+                                        data-option="table"
+                                        >Table</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a
+                                        class="nav-link"
+                                        href="javascript:void(0);"
+                                        data-target="propagation.viewOption"
+                                        data-action="click->propagation#setChart"
+                                        data-option="chart"
+                                        >Chart</a>
+                                    </li>
 
-                            <div data-target="propagation.numPageWrapper" class="control-div ml-auto p-0 {{ if .propagation.chartView }}d-none{{ end }}" >
-                                <div class="control-label">Page Size:</div>
-                                <select data-target="propagation.selectedNum" data-action="change->propagation#numberOfRowsChanged" class="form-control" style="width: 70px;">
-                                    {{$selectedNum := .propagation.selectedNum}}
-                                    {{ range $index, $filter := .propagation.pageSizeSelector}}
-                                    <option value="{{$index}}" {{ if eq $index $selectedNum}} selected {{ end }}>{{$filter}}</option>
-                                    {{ end }}
-                                </select>
+                                </ul>
                             </div>
-                            <div class="d-flex {{ if .propagation.chartView }}d-none{{ end }}" data-target="propagation.paginationButtonsWrapper">
-                               <a href="javascript:void(0)" data-target="propagation.previousPageButton" data-action="click->propagation#loadPreviousPage" class="mr-2 {{ if lt .propagation.previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
-
-                                <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="propagation.currentPage" data-current-page="{{ .propagation.currentPage }}" class="text-muted"> {{ .propagation.currentPage }}</span> of <span data-target="propagation.totalPageCount" class="text-muted">{{ .propagation.totalPages }}</span>
-                                </p>   
-
-                                <a href="javascript:void(0)" data-target="propagation.nextPageButton" data-action="click->propagation#loadNextPage" class="ml-2 {{ if not .propagation.nextPage }}d-none{{ end }}"> Next&gt;</a>
-                            </div>
+                        </div>
+                        <div class="d-flex chart-control-wrapper mr-3 p-0"
+                        data-target="propagation.recordSetSelector">
+                        <div class="chart-control propagation-control mx-auto">
+                            <ul class="nav nav-pills">
+                                <li class="nav-item">
+                                    <a 
+                                    data-target="propagation.selectedRecordSet"
+                                    data-action="click->propagation#setBothRecordSet" 
+                                    class="nav-link active"
+                                    href="javascript:void(0);" 
+                                    data-option="both">Both</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a 
+                                    data-target="propagation.selectedRecordSet"
+                                    data-action="click->propagation#setBlocksRecordSet" 
+                                    class="nav-link"
+                                    href="javascript:void(0);" 
+                                    data-option="blocks">Blocks</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a 
+                                    data-target="propagation.selectedRecordSet"
+                                    data-action="click->propagation#setVotesRecordSet" 
+                                    class="nav-link"
+                                    href="javascript:void(0);" 
+                                    data-option="votes">Votes</a>
+                                </li>
+                            </ul>
                         </div>
                     </div>
 
-                <div class="{{ if not .propagation.nextPage }}d-none{{ end }}" data-target="propagation.tablesWrapper">
-                    {{/*combine view*/}}
-                    <table class="table collapsible mx-auto {{ if not .propagation.both }}d-none{{ end }}" data-target="propagation.table">
-                        {{range $index, $block := .propagation.records}}
-                            <tbody data-target="propagation.blocksTbody" data-block-hash="{{$block.BlockHash}}">
-                                <tr>
-                                    <td colspan="100">
-                                        <span class="d-inline-block"><b>Height</b>: {{$block.BlockHeight}}</span> &#8195;
-                                        <span class="d-inline-block"><b>Timestamp</b>: {{$block.BlockInternalTime}}</span>
-                                        &#8195;
-                                        <span class="d-inline-block"><b>Received</b>: {{$block.BlockReceiveTime}}</span>
-                                        &#8195;
-                                        <span class="d-inline-block"><b>Hash</b>: <a target="_blank"
-                                                href="https://explorer.dcrdata.org/block/{{$block.BlockHeight}}">{{$block.BlockHash}}</a></span>
-                                    </td>
-                                </tr>
-                            </tbody>
-                            <tbody data-target="propagation.votesTbody" data-block-hash="{{$block.BlockHash}}">
-                                <tr style="white-space: nowrap;">
-                                    <td style="width: 120px;">Voting On</td>
-                                    <td style="width: 120px;">Block Hash</td>
-                                    <td style="width: 120px;">Validator ID</td>
-                                    <td style="width: 120px;">Validity</td>
-                                    <td style="width: 120px;">Block Receive</td>
-                                    <td style="width: 120px;">Block Receive Time Diff</td>
-                                    <td style="width: 120px;">Hash</td>
-                                </tr>
-                                {{range $index, $vote := $block.Votes}}
-                                    <tr>
-                                        <td><a target="_blank"
-                                            href="https://explorer.dcrdata.org/block/{{$vote.VotingOn}}">{{$vote.VotingOn}}</a>
-                                        </td>
-                                        <td><a target="_blank"
-                                            href="https://explorer.dcrdata.org/block/{{$vote.BlockHash}}">...{{$vote.ShortBlockHash}}</a>
-                                        </td>
-                                        <td>{{$vote.ValidatorId}}</td>
-                                        <td>{{$vote.Validity}}</td>
-                                        <td>{{$vote.ReceiveTime}}</td>
-                                        <td>{{$vote.BlockReceiveTimeDiff}}s</td>
-                                        <td><a target="_blank"
-                                            href="https://explorer.dcrdata.org/tx/{{$vote.Hash}}">{{$vote.Hash}}</a></td>
-                                    </tr>
-                                {{end}}
-                            </tbody>
-                            <tbody>
-                                <tr>
-                                    <td colspan="7" height="15" style="border: none !important;"></td>
-                                </tr>
-                            </tbody>
+                    <div data-target="propagation.numPageWrapper" class="control-div p-0 {{ if .propagation.chartView }}d-none{{ end }}" >
+                        <div class="control-label">Page Size:</div>
+                        <select data-target="propagation.selectedNum" data-action="change->propagation#numberOfRowsChanged" class="form-control" style="width: 70px;">
+                            {{$selectedNum := .propagation.selectedNum}}
+                            {{ range $index, $filter := .propagation.pageSizeSelector}}
+                            <option value="{{$index}}" {{ if eq $index $selectedNum}} selected {{ end }}>{{$filter}}</option>
+                            {{ end }}
+                        </select>
+                    </div>
+                    <div class="d-flex mr-auto {{ if .propagation.chartView }}d-none{{ end }}" data-target="propagation.paginationButtonsWrapper">
+                     <a href="javascript:void(0)" data-target="propagation.previousPageButton" data-action="click->propagation#loadPreviousPage" class="mr-2 {{ if lt .propagation.previousPage 1 }}d-none{{ end }}">&lt;Previous </a>
+
+                     <p class="text-muted" style="white-space: nowrap;"> Page <span data-target="propagation.currentPage" data-current-page="{{ .propagation.currentPage }}" class="text-muted"> {{ .propagation.currentPage }}</span> of <span data-target="propagation.totalPageCount" class="text-muted">{{ .propagation.totalPages }}</span>
+                     </p>   
+
+                     <a href="javascript:void(0)" data-target="propagation.nextPageButton" data-action="click->propagation#loadNextPage" class="ml-2 {{ if not .propagation.nextPage }}d-none{{ end }}"> Next&gt;</a>
+                 </div>
+             </div>
+         </div>
+
+         <div class="{{ if not .propagation.nextPage }}d-none{{ end }}" data-target="propagation.tablesWrapper">
+            {{/*combine view*/}}
+            <table class="table collapsible mx-auto {{ if not .propagation.both }}d-none{{ end }}" data-target="propagation.table">
+                {{range $index, $block := .propagation.records}}
+                <tbody data-target="propagation.blocksTbody" data-block-hash="{{$block.BlockHash}}">
+                    <tr>
+                        <td colspan="100">
+                            <span class="d-inline-block"><b>Height</b>: {{$block.BlockHeight}}</span> &#8195;
+                            <span class="d-inline-block"><b>Timestamp</b>: {{$block.BlockInternalTime}}</span>
+                            &#8195;
+                            <span class="d-inline-block"><b>Received</b>: {{$block.BlockReceiveTime}}</span>
+                            &#8195;
+                            <span class="d-inline-block"><b>Hash</b>: <a target="_blank"
+                                href="https://explorer.dcrdata.org/block/{{$block.BlockHeight}}">{{$block.BlockHash}}</a></span>
+                            </td>
+                        </tr>
+                    </tbody>
+                    <tbody data-target="propagation.votesTbody" data-block-hash="{{$block.BlockHash}}">
+                        <tr style="white-space: nowrap;">
+                            <td style="width: 120px;">Voting On</td>
+                            <td style="width: 120px;">Block Hash</td>
+                            <td style="width: 120px;">Validator ID</td>
+                            <td style="width: 120px;">Validity</td>
+                            <td style="width: 120px;">Block Receive</td>
+                            <td style="width: 120px;">Block Receive Time Diff</td>
+                            <td style="width: 120px;">Hash</td>
+                        </tr>
+                        {{range $index, $vote := $block.Votes}}
+                        <tr>
+                            <td><a target="_blank"
+                                href="https://explorer.dcrdata.org/block/{{$vote.VotingOn}}">{{$vote.VotingOn}}</a>
+                            </td>
+                            <td><a target="_blank"
+                                href="https://explorer.dcrdata.org/block/{{$vote.BlockHash}}">...{{$vote.ShortBlockHash}}</a>
+                            </td>
+                            <td>{{$vote.ValidatorId}}</td>
+                            <td>{{$vote.Validity}}</td>
+                            <td>{{$vote.ReceiveTime}}</td>
+                            <td>{{$vote.BlockReceiveTimeDiff}}s</td>
+                            <td><a target="_blank"
+                                href="https://explorer.dcrdata.org/tx/{{$vote.Hash}}">{{$vote.Hash}}</a></td>
+                            </tr>
+                            {{end}}
+                        </tbody>
+                        <tbody>
+                            <tr>
+                                <td colspan="7" height="15" style="border: none !important;"></td>
+                            </tr>
+                        </tbody>
                         {{end}}
                     </table>
 
                     {{/*blocks only*/}}
                     <table class="table d-none mx-auto {{ if not .propagation.blocks }}d-none{{ end }}" data-target="propagation.blocksTable">
                         <thead>
-                        <tr style="white-space: nowrap;">
-                            <th>Height</th>
-                            <th>Timestamp</th>
-                            <th>Received</th>
-                            <th>Delay</th>
-                            <th>Hash</th>
-                        </tr>
+                            <tr style="white-space: nowrap;">
+                                <th>Height</th>
+                                <th>Timestamp</th>
+                                <th>Received</th>
+                                <th>Delay</th>
+                                <th>Hash</th>
+                            </tr>
                         </thead>
                         <tbody data-target="propagation.blocksTableBody">
                         </tbody>
@@ -145,16 +166,16 @@
                     {{/*votes only*/}}
                     <table data-target="propagation.votesTable" class="table d-none mx-auto {{ if not .propagation.votes }}d-none{{ end }}">
                         <thead>
-                        <tr style="white-space: nowrap;">
-                            <th>Voting On</th>
-                            <th>Block Hash</th>
-                            <th>Validator ID</th>
-                            <th>Validity</th>
-                            <th>Received</th>
-                            <th>Block Time Diff</th>
-                            <th>Block Receive Time Diff</th>
-                            <th>Hash</th>
-                        </tr>
+                            <tr style="white-space: nowrap;">
+                                <th>Voting On</th>
+                                <th>Block Hash</th>
+                                <th>Validator ID</th>
+                                <th>Validity</th>
+                                <th>Received</th>
+                                <th>Block Time Diff</th>
+                                <th>Block Receive Time Diff</th>
+                                <th>Hash</th>
+                            </tr>
                         </thead>
                         <tbody data-target="propagation.votesTableBody">
                         </tbody>


### PR DESCRIPTION
fixes #135

Made table view the default view for propagation page, removed dropped and used selectors, hide both selector option on chart view.

![image](https://user-images.githubusercontent.com/27733432/62491842-ee3da080-b7c4-11e9-8f6b-f35031f254f1.png)

![image](https://user-images.githubusercontent.com/27733432/62491859-fd245300-b7c4-11e9-87dd-2b34e2198a15.png)
