### PR TITLE
Broken pipe error in template execution

### DIFF
--- a/exchanges/hubs.go
+++ b/exchanges/hubs.go
@@ -31,7 +31,7 @@ var (
 		ticks.Bittrex,
 		ticks.Bittrexusd,
 		ticks.Binance,
-		ticks.Bleutrade,
+		// ticks.Bleutrade,
 		ticks.Poloniex,
 	}
 )

--- a/exchanges/ticks/collectors.go
+++ b/exchanges/ticks/collectors.go
@@ -50,7 +50,7 @@ var (
 		Bittrex:    NewBittrexCollector,
 		Bittrexusd: NewBittrexUSDCollector,
 		Poloniex:   NewPoloniexCollector,
-		Bleutrade:  NewBleutradeCollector,
+		// Bleutrade:  NewBleutradeCollector,
 		Binance:    NewBinanceCollector,
 	}
 

--- a/postgres/exchange_ticks.go
+++ b/postgres/exchange_ticks.go
@@ -70,7 +70,7 @@ func (pg *PgDb) RegisterExchange(ctx context.Context, exchange ticks.ExchangeDat
 // StoreExchangeTicks
 func (pg *PgDb) StoreExchangeTicks(ctx context.Context, name string, interval int, pair string, ticks []ticks.Tick) (time.Time, error) {
 	if len(ticks) == 0 {
-		return zeroTime, fmt.Errorf("No ticks recieved for %s", name)
+		return zeroTime, fmt.Errorf("No ticks received for %s", name)
 	}
 
 	exchange, err := models.Exchanges(models.ExchangeWhere.Name.EQ(name)).One(ctx, pg.db)


### PR DESCRIPTION
Closes #167 

This error is as a result of the connection been closed by the client while the server is still writing the response. It is not possible to show the error to the client over `HTTP` as the connection has already been closed.
This PR checks template execution error and filter it out.

Also closes #166 