### PR TITLE
Print configuration file options on command-line help menu

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -48,7 +48,6 @@ var (
 func defaultFileOptions() ConfigFileOptions {
 	cfg := ConfigFileOptions{
 		LogFile:         defaultLogFilename,
-		ConfigFile:      DefaultConfigFilename,
 		DBHost:          defaultDbHost,
 		DBPort:          defaultDbPort,
 		DBUser:          defaultDbUser,
@@ -87,7 +86,6 @@ type Config struct {
 type ConfigFileOptions struct {
 	// General application behaviour
 	LogFile    string `short:"L" long:"logfile" description:"File name of the log file"`
-	ConfigFile string `short:"C" long:"Configfile" description:"Path to Configuration file"`
 	DebugLevel string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
 	Quiet      bool   `short:"q" long:"quiet" description:"Easy way to set debuglevel to error"`
 
@@ -102,7 +100,7 @@ type ConfigFileOptions struct {
 	HTTPHost string `long:"httphost" description:"HTTP server host address or IP when running godcr in http mode."`
 	HTTPPort string `long:"httpport" description:"HTTP server port when running godcr in http mode."`
 	// Exchange collector
-	DisableExchangeTicks bool     `long:"disablexcticks" decription:"Disables collection of ticker data from exchanges"`
+	DisableExchangeTicks bool     `long:"disablexcticks" description:"Disables collection of ticker data from exchanges"`
 	DisabledExchanges    []string `long:"disableexchange" description:"Disable data collection for this exchange"`
 
 	// PoW collector
@@ -128,32 +126,36 @@ type ConfigFileOptions struct {
 	SyncSources   []string `long:"syncsource" description:"Address of remote instance to sync data from"`
 	SyncDatabases []string `long:"syncdatabase" description:"Database to sync remote data to"`
 
-	CommunityStatOptions `group:"Community Stat"`
+	CommunityStatOptions
 }
 
 // CommandLineOptions holds the top-level options/flags that are displayed on the command-line menu
 type CommandLineOptions struct {
-	Reset    bool `short:"R" long:"reset" description:"Drop all database tables and start over"`
-	HttpMode bool `long:"http" description:"Launch http server"`
+	Reset      bool   `short:"R" long:"reset" description:"Drop all database tables and start over"`
+	ConfigFile string `short:"C" long:"configfile" description:"Path to Configuration file"`
+	HttpMode   bool   `long:"http" description:"Launch http server"`
 }
 
 type CommunityStatOptions struct {
 	// Community stat
-	DisableCommunityStat  bool     `long:"disablecommstat" description:"Disables periodic community stat collection"`
-	RedditStatInterval int64    `long:"redditstatinterval" description:"Collection interval for Reddit community stat"`
-	Subreddit             []string `long:"subreddit" description:"List of subreddit for community stat collection"`
-	TwitterHandles        []string `long:"twitterhandle" description:"List of twitter handles community stat collection"`
-	TwitterStatInterval   int      `long:"twitterstatinterval" description:"Number of minutes between Twitter stat collection"`
-	GithubRepositories    []string `long:"githubrepository" description:"List of Github repositories to track"`
-	GithubStatInterval    int      `long:"githubstatinterval" description:"Number of minutes between Github stat collection"`
-	YoutubeChannelName	  []string `long:"youtubechannelname" description:"List of Youtube channel names to be tracked"`
-	YoutubeChannelId	  []string `long:"youtubechannelid" description:"List of Youtube channel ID to be tracked"`
-	YoutubeStatInterval   int      `long:"youtubestatinterval" description:"Number of minutes between Youtube stat collection"`
-	YoutubeDataApiKey     string   `long:"youtubedataapikey" description:"Youtube data API key gotten from google developer console"`
+	DisableCommunityStat bool     `long:"disablecommstat" description:"Disables periodic community stat collection"`
+	RedditStatInterval   int64    `long:"redditstatinterval" description:"Collection interval for Reddit community stat"`
+	Subreddit            []string `long:"subreddit" description:"List of subreddit for community stat collection"`
+	TwitterHandles       []string `long:"twitterhandle" description:"List of twitter handles community stat collection"`
+	TwitterStatInterval  int      `long:"twitterstatinterval" description:"Number of minutes between Twitter stat collection"`
+	GithubRepositories   []string `long:"githubrepository" description:"List of Github repositories to track"`
+	GithubStatInterval   int      `long:"githubstatinterval" description:"Number of minutes between Github stat collection"`
+	YoutubeChannelName   []string `long:"youtubechannelname" description:"List of Youtube channel names to be tracked"`
+	YoutubeChannelId     []string `long:"youtubechannelid" description:"List of Youtube channel ID to be tracked"`
+	YoutubeStatInterval  int      `long:"youtubestatinterval" description:"Number of minutes between Youtube stat collection"`
+	YoutubeDataApiKey    string   `long:"youtubedataapikey" description:"Youtube data API key gotten from google developer console"`
 }
 
 func defaultConfig() Config {
 	return Config{
+		CommandLineOptions: CommandLineOptions{
+			ConfigFile: DefaultConfigFilename,
+		},
 		ConfigFileOptions: defaultFileOptions(),
 	}
 }
@@ -161,10 +163,10 @@ func defaultConfig() Config {
 func LoadConfig() (*Config, []string, error) {
 	cfg := defaultConfig()
 	parser := flags.NewParser(&cfg, flags.IgnoreUnknown)
-	err := flags.NewIniParser(parser).ParseFile(cfg.ConfigFileOptions.ConfigFile)
+	err := flags.NewIniParser(parser).ParseFile(cfg.ConfigFile)
 	if err != nil {
 		if _, ok := err.(*os.PathError); ok {
-			fmt.Printf("Missing Config file %s in current directory\n", cfg.ConfigFileOptions.ConfigFile)
+			fmt.Printf("Missing Config file %s in current directory\n", cfg.ConfigFile)
 		} else {
 			return nil, nil, err
 		}

--- a/sample-dcrextdata.conf
+++ b/sample-dcrextdata.conf
@@ -53,8 +53,6 @@
 ; The number of minute between sync intervals
 ;syncinterval = 60
 
-[Community Stat]
-
 ; Disables periodic community stat collection
 ;disablecommstat = false
 


### PR DESCRIPTION
This PR add the ability to print configuration file options on command-line help menu.
It also use alternative config file if set from the command line.

![image](https://user-images.githubusercontent.com/11990092/75090614-dc56fb80-5564-11ea-9e11-9820723c5d4f.png)
